### PR TITLE
Adds a few more scary gh oauth scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This version will always ask for your confirmation before executing any commands
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'admin:org'|'admin:enterprise'"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key'|delete_repo'|(write|delete)_packages')"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         # Use a portable prompt that works in both bash and zsh
         printf "Are you sure you want to proceed with this token? [y/N]: "
@@ -118,7 +118,7 @@ This version will always ask for your confirmation before executing any commands
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'admin:org'|'admin:enterprise'"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key'|delete_repo'|(write|delete)_packages')"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         # Use a portable prompt that works in both bash and zsh
         printf "Are you sure you want to proceed with this token? [y/N]: "

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This version will always ask for your confirmation before executing any commands
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key'|delete_repo'|(write|delete)_packages')"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "(admin:|manage_|write:public_key|delete_repo|(write|delete)_packages)"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         # Use a portable prompt that works in both bash and zsh
         printf "Are you sure you want to proceed with this token? [y/N]: "

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This version will always ask for your confirmation before executing any commands
       fi
 
       # 2. Warn if the token has highly privileged scopes.
-      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key'|delete_repo'|(write|delete)_packages')"; then
+      if gh auth status 2>/dev/null | grep "Token scopes:" | grep -q -E "'(admin:|manage_|write:public_key|delete_repo|(write|delete)_packages)'"; then
         echo "⚠️  Warning: Your GitHub token has highly privileged scopes (e.g., admin:org, admin:enterprise)."
         # Use a portable prompt that works in both bash and zsh
         printf "Are you sure you want to proceed with this token? [y/N]: "


### PR DESCRIPTION
This pull request updates the logic in the `README.md` examples to improve the detection of highly privileged GitHub token scopes. The main change is expanding the regular expression used to match more privileged scopes, making the security warning more comprehensive.

Security improvements:

* Expanded the regular expression in the privilege check to include additional sensitive scopes such as `admin:`, `manage_`, `write:public_key`, `delete_repo`, and both `write_packages` and `delete_packages`, instead of only `admin:org` and `admin:enterprise`. This change appears in two code snippets in the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L121-R121)