### PR TITLE
feat: enable network rules and expand github api paths

### DIFF
--- a/.copilot_here/network.json
+++ b/.copilot_here/network.json
@@ -1,44 +1,9 @@
 {
-  "enabled": false,
+  "enabled": true,
   "enable_logging": true,
   "inherit_default_rules": true,
   "mode": "enforce",
   "allowed_rules": [
-    {
-      "host": "api.github.com",
-      "allowed_paths": [
-        "/user",
-        "/graphql",
-        "/repos/github/copilot-cli/releases/latest"
-      ]
-    },
-    {
-      "host": "api.githubcopilot.com",
-      "allowed_paths": [
-        "/models",
-        "/mcp/readonly",
-        "/chat/completions",
-        "/agents/swe/custom-agents/{{GITHUB_OWNER}}/{{GITHUB_REPO}}*"
-      ]
-    },
-    {
-      "host": "api.individual.githubcopilot.com",
-      "allowed_paths": [
-        "/models",
-        "/mcp/readonly",
-        "/chat/completions",
-        "/agents/swe/custom-agents/{{GITHUB_OWNER}}/{{GITHUB_REPO}}*"
-      ]
-    },
-    {
-      "host": "api.enterprise.githubcopilot.com",
-      "allowed_paths": [
-        "/models",
-        "/mcp/readonly",
-        "/chat/completions",
-        "/agents/swe/custom-agents/{{GITHUB_OWNER}}/{{GITHUB_REPO}}*"
-      ]
-    },
     {
       "host": "api.nuget.org",
       "allowed_paths": [

--- a/default-airlock-rules.json
+++ b/default-airlock-rules.json
@@ -7,7 +7,9 @@
       "allowed_paths": [
         "/user",
         "/graphql",
-        "/repos/github/copilot-cli/releases/latest"
+        "/repos/github/copilot-cli/releases/latest",
+        "/copilot_internal/user",
+        "/repos/{{GITHUB_OWNER}}/{{GITHUB_REPO}}*"
       ]
     },
     {


### PR DESCRIPTION
Enable network filtering in Copilot configuration and remove
duplicate GitHub API rules from network.json. Expand allowed paths
in default airlock rules to include internal user endpoint and
repository access with variable substitution for dynamic repo
references.