### PR TITLE
fix: Use single quotes for build_args to prevent shell variable expansion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -435,7 +435,7 @@ jobs:
       - name: Prepare build args
         id: args
         run: |
-          ARGS="${{ matrix.build_args }}"
+          ARGS='${{ matrix.build_args }}'
           ARGS="${ARGS//\$COPILOT_VERSION/${{ needs.prepare-versions.outputs.copilot_version }}}"
           ARGS="${ARGS//\$PLAYWRIGHT_VERSION/${{ needs.prepare-versions.outputs.playwright_version }}}"
           ARGS="${ARGS//\$DOTNET_8_VERSION/${{ needs.prepare-versions.outputs.dotnet_8_version }}}"


### PR DESCRIPTION
## Summary
- The matrix `build_args` values use `$PLACEHOLDER` tokens (e.g. `$COPILOT_VERSION`) intended for bash string substitution in the "Prepare build args" step
- Using double quotes on `ARGS="${{ matrix.build_args }}"` caused bash to expand these as shell variables (unset = empty) before the substitution could replace them
- This meant **all Docker build args were always empty**, with images silently falling back to Dockerfile ARG defaults
- The `csharp-ls` install broke because `dotnet tool install --version ""` is an error (unlike npm/go which tolerate empty versions)
- Fix: switch to single quotes `ARGS='${{ matrix.build_args }}'` to preserve the `$` placeholders for the substitution step

## Test plan
- [ ] `prepare-versions` resolves all versions correctly
- [ ] Docker build commands show non-empty `--build-arg` values
- [ ] All image builds pass, including dotnet and dotnet-10

Generated with [Claude Code](https://claude.com/claude-code) and [GitButler](https://gitbutler.com)