### PR TITLE
fix: Fix Java Docker build and add PlantUML

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -175,9 +175,10 @@ Extends the base image with:
 - Java JDK 21 (Eclipse Temurin)
 - Maven
 - Gradle
+- PlantUML (with Graphviz)
 - Eclipse JDT Language Server
 
-**Use Case**: Java development, Maven/Gradle builds, Spring Boot applications
+**Use Case**: Java development, Maven/Gradle builds, Spring Boot applications, UML diagrams
 
 ## Container Runtime Support
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All functions support switching between Docker image variants using flags:
 - **`--rust`** (`-rs`) - Rust image (includes Rust toolchain)
 - **`--dotnet-rust`** (`-dr`) - .NET + Rust image
 - **`--golang`** (`-go`) - Golang image (includes Go toolchain)
-- **`--java`** (`-j`) - Java image (includes JDK 21, Maven, Gradle)
+- **`--java`** (`-j`) - Java image (includes JDK 21, Maven, Gradle, PlantUML)
 - **`--image <name>`** (`-i`) - Use any custom Docker image (e.g., `my-image:tag`, `registry.io/org/image:v1`)
 
 ### Additional Options
@@ -558,7 +558,7 @@ This project provides multiple Docker image variants for different development s
 | `rust` | `--rust` | Rust toolchain |
 | `dotnet-rust` | `--dotnet-rust` | .NET + Rust combined |
 | `golang` | `--golang` | Go toolchain |
-| `java` | `--java` | Java JDK 21 with Maven & Gradle |
+| `java` | `--java` | Java JDK 21 with Maven, Gradle & PlantUML |
 | *(custom)* | `--image <name>` | Any custom Docker image |
 
 ### Choosing the Right Image

--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -104,7 +104,7 @@ public sealed class RunCommand : ICommand
 
     _golangOption = new Option<bool>("--golang") { Description = "[-go] Use Golang image variant" };
 
-    _javaOption = new Option<bool>("--java") { Description = "[-j] Use Java image variant (JDK 21 + Maven + Gradle)" };
+    _javaOption = new Option<bool>("--java") { Description = "[-j] Use Java image variant (JDK 21 + Maven + Gradle + PlantUML)" };
 
     _mountOption = new Option<string[]>("--mount") { Description = "Mount directory (read-only). Format: path or host:container" };
 

--- a/docker/generated/Dockerfile.java
+++ b/docker/generated/Dockerfile.java
@@ -48,14 +48,16 @@ RUN ARCH=$(dpkg --print-architecture) \
 # Install Java (Eclipse Temurin JDK 21), Maven, and Gradle
 # Using Eclipse Temurin - widely used, well-maintained OpenJDK distribution
 
-# Add Eclipse Temurin repository
-RUN apt-get update && apt-get install -y gnupg \
+# Add Eclipse Temurin repository and install JDK
+RUN apt-get update && apt-get install -y gnupg unzip \
   && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" > /etc/apt/sources.list.d/adoptium.list \
   && apt-get update && apt-get install -y temurin-21-jdk \
   && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture)
+# Set JAVA_HOME dynamically based on architecture (ENV can't use command substitution)
+RUN ln -s /usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-21-jdk
+ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven
@@ -72,12 +74,22 @@ RUN curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSIO
   && ln -s /usr/local/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle \
   && rm gradle.zip
 
+# Install PlantUML
+ARG PLANTUML_VERSION=1.2025.2
+RUN curl -fsSL "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" -o /usr/local/lib/plantuml.jar \
+  && echo '#!/bin/sh\nexec java -jar /usr/local/lib/plantuml.jar "$@"' > /usr/local/bin/plantuml \
+  && chmod +x /usr/local/bin/plantuml
+
+# Install Graphviz (required by PlantUML for many diagram types)
+RUN apt-get update && apt-get install -y graphviz \
+  && rm -rf /var/lib/apt/lists/*
+
 # Make Maven and Gradle caches writable by all users
 RUN mkdir -p /home/appuser/.m2 /home/appuser/.gradle \
   && chmod -R a+rwX /home/appuser/.m2 /home/appuser/.gradle
 
 # Verify installations
-RUN java --version && mvn --version && gradle --version
+RUN java --version && mvn --version && gradle --version && plantuml -version
 
 # --- snippet: lsp-typescript ---
 # Install TypeScript Language Server for code intelligence
@@ -93,7 +105,7 @@ RUN mkdir -p /etc/copilot/lsp-config.d && \
 # --- snippet: lsp-java ---
 # Install Eclipse JDT Language Server for Java code intelligence
 ARG JDTLS_VERSION=1.43.0
-ARG JDTLS_TIMESTAMP=202501232208
+ARG JDTLS_TIMESTAMP=202412191447
 RUN mkdir -p /usr/local/share/jdtls \
   && curl -fsSL "https://download.eclipse.org/jdtls/milestones/${JDTLS_VERSION}/jdt-language-server-${JDTLS_VERSION}-${JDTLS_TIMESTAMP}.tar.gz" -o jdtls.tar.gz \
   && tar -C /usr/local/share/jdtls -xzf jdtls.tar.gz \

--- a/docker/snippets/java.Dockerfile
+++ b/docker/snippets/java.Dockerfile
@@ -1,14 +1,16 @@
 # Install Java (Eclipse Temurin JDK 21), Maven, and Gradle
 # Using Eclipse Temurin - widely used, well-maintained OpenJDK distribution
 
-# Add Eclipse Temurin repository
-RUN apt-get update && apt-get install -y gnupg \
+# Add Eclipse Temurin repository and install JDK
+RUN apt-get update && apt-get install -y gnupg unzip \
   && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" > /etc/apt/sources.list.d/adoptium.list \
   && apt-get update && apt-get install -y temurin-21-jdk \
   && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture)
+# Set JAVA_HOME dynamically based on architecture (ENV can't use command substitution)
+RUN ln -s /usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-21-jdk
+ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven
@@ -25,9 +27,19 @@ RUN curl -fsSL "https://services.gradle.org/distributions/gradle-${GRADLE_VERSIO
   && ln -s /usr/local/gradle-${GRADLE_VERSION}/bin/gradle /usr/local/bin/gradle \
   && rm gradle.zip
 
+# Install PlantUML
+ARG PLANTUML_VERSION=1.2025.2
+RUN curl -fsSL "https://github.com/plantuml/plantuml/releases/download/v${PLANTUML_VERSION}/plantuml-${PLANTUML_VERSION}.jar" -o /usr/local/lib/plantuml.jar \
+  && echo '#!/bin/sh\nexec java -jar /usr/local/lib/plantuml.jar "$@"' > /usr/local/bin/plantuml \
+  && chmod +x /usr/local/bin/plantuml
+
+# Install Graphviz (required by PlantUML for many diagram types)
+RUN apt-get update && apt-get install -y graphviz \
+  && rm -rf /var/lib/apt/lists/*
+
 # Make Maven and Gradle caches writable by all users
 RUN mkdir -p /home/appuser/.m2 /home/appuser/.gradle \
   && chmod -R a+rwX /home/appuser/.m2 /home/appuser/.gradle
 
 # Verify installations
-RUN java --version && mvn --version && gradle --version
+RUN java --version && mvn --version && gradle --version && plantuml -version

--- a/docker/snippets/lsp-java.Dockerfile
+++ b/docker/snippets/lsp-java.Dockerfile
@@ -1,6 +1,6 @@
 # Install Eclipse JDT Language Server for Java code intelligence
 ARG JDTLS_VERSION=1.43.0
-ARG JDTLS_TIMESTAMP=202501232208
+ARG JDTLS_TIMESTAMP=202412191447
 RUN mkdir -p /usr/local/share/jdtls \
   && curl -fsSL "https://download.eclipse.org/jdtls/milestones/${JDTLS_VERSION}/jdt-language-server-${JDTLS_VERSION}-${JDTLS_TIMESTAMP}.tar.gz" -o jdtls.tar.gz \
   && tar -C /usr/local/share/jdtls -xzf jdtls.tar.gz \

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -65,9 +65,10 @@ Extends the base image with:
 - Java JDK 21 (Eclipse Temurin)
 - Maven
 - Gradle
+- PlantUML (with Graphviz)
 - Eclipse JDT Language Server (jdtls)
 
-**Use Case:** Java development, Maven/Gradle builds, Spring Boot applications
+**Use Case:** Java development, Maven/Gradle builds, Spring Boot applications, UML diagrams
 
 ## Playwright Image: `dotnet-playwright`
 **Tag:** `ghcr.io/gordonbeeming/copilot_here:dotnet-playwright`


### PR DESCRIPTION
## Summary

- Fix JDTLS download URL timestamp (was returning 404)
- Fix `JAVA_HOME` ENV - can't use command substitution in Dockerfile `ENV`, use symlink instead
- Add `unzip` dependency needed for Gradle install
- Add PlantUML (with Graphviz) to the Java image
- Update docs, CLI description, and site to reflect PlantUML inclusion

Follow-up to #87

## Test plan

- [x] `dotnet build` compiles
- [x] `dotnet test` - all 475 tests pass
- [x] `docker build -f docker/generated/Dockerfile.java .` builds locally
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)