### PR TITLE
fix: Preserve symlinks when updating shell profiles

### DIFF
--- a/copilot_here.ps1
+++ b/copilot_here.ps1
@@ -189,9 +189,12 @@ function Update-ProfileWithMarkers {
     $block = "`n`n$markerStart`nif (Test-Path '$scriptPathEscaped') {`n    . '$scriptPathEscaped'`n}`n$markerEnd`n"
     
     $profileContent = $profileContent + $block
-    # Use WriteAllText on resolved path to preserve symlinks (e.g. GNU Stow)
-    $resolvedPath = (Resolve-Path $ProfilePath -ErrorAction SilentlyContinue)?.Path ?? $ProfilePath
-    [System.IO.File]::WriteAllText($resolvedPath, $profileContent.TrimStart())
+    # Resolve symlink target to preserve symlinks (e.g. GNU Stow)
+    # Use PS 5.1-compatible null handling (no ?. or ?? operators)
+    $resolved = Resolve-Path $ProfilePath -ErrorAction SilentlyContinue
+    if ($resolved) { $resolvedPath = $resolved.Path } else { $resolvedPath = $ProfilePath }
+    # Explicitly use UTF-8 with BOM to match Set-Content default encoding
+    [System.IO.File]::WriteAllText($resolvedPath, $profileContent.TrimStart(), [System.Text.Encoding]::UTF8)
     Write-Host "   [OK] $(Split-Path $ProfilePath -Leaf)" -ForegroundColor Gray
 }
 

--- a/copilot_here.sh
+++ b/copilot_here.sh
@@ -248,9 +248,20 @@ fi
 $marker_end
 EOF
   
-  # Use cat+rm instead of mv to preserve symlinks (e.g. GNU Stow)
-  cat "$temp_file" > "$profile_path"
-  rm "$temp_file"
+  # Preserve symlinks: if target is a symlink, mv into the resolved path atomically;
+  # otherwise write through the path to handle regular files too.
+  local real_path
+  if [ -L "$profile_path" ]; then
+    real_path="$(readlink -f "$profile_path")"
+    mv "$temp_file" "$real_path"
+  else
+    if ! cat "$temp_file" > "$profile_path"; then
+      echo "   ✗ Failed to write $profile_name" >&2
+      rm -f "$temp_file"
+      return 1
+    fi
+    rm "$temp_file"
+  fi
   echo "   ✓ $profile_name"
 }
 


### PR DESCRIPTION
Closes #89

## Summary
- Shell profile update (`copilot_here.sh`) used `mv` which replaced symlinks with regular files — now uses `cat`+`rm` to write through symlinks
- PowerShell update (`copilot_here.ps1`) used `Set-Content` which recreates the file — now resolves the symlink target before writing

## Test plan
- [ ] Create a symlinked `.zshrc` (e.g. via GNU Stow), run copilot_here update, verify symlink is preserved
- [ ] Run copilot_here update on a regular (non-symlink) `.zshrc`, verify it still works
- [ ] On Windows, run PowerShell profile update with a symlinked profile, verify symlink preserved