### PR TITLE
chore: Update Java JDK to version 25

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All functions support switching between Docker image variants using flags:
 - **`--rust`** (`-rs`) - Rust image (includes Rust toolchain)
 - **`--dotnet-rust`** (`-dr`) - .NET + Rust image
 - **`--golang`** (`-go`) - Golang image (includes Go toolchain)
-- **`--java`** (`-j`) - Java image (includes JDK 21, Maven, Gradle, PlantUML)
+- **`--java`** (`-j`) - Java image (includes JDK 25, Maven, Gradle, PlantUML)
 - **`--image <name>`** (`-i`) - Use any custom Docker image (e.g., `my-image:tag`, `registry.io/org/image:v1`)
 
 ### Additional Options
@@ -558,7 +558,7 @@ This project provides multiple Docker image variants for different development s
 | `rust` | `--rust` | Rust toolchain |
 | `dotnet-rust` | `--dotnet-rust` | .NET + Rust combined |
 | `golang` | `--golang` | Go toolchain |
-| `java` | `--java` | Java JDK 21 with Maven, Gradle & PlantUML |
+| `java` | `--java` | Java JDK 25 with Maven, Gradle & PlantUML |
 | *(custom)* | `--image <name>` | Any custom Docker image |
 
 ### Choosing the Right Image

--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -104,7 +104,7 @@ public sealed class RunCommand : ICommand
 
     _golangOption = new Option<bool>("--golang") { Description = "[-go] Use Golang image variant" };
 
-    _javaOption = new Option<bool>("--java") { Description = "[-j] Use Java image variant (JDK 21 + Maven + Gradle + PlantUML)" };
+    _javaOption = new Option<bool>("--java") { Description = "[-j] Use Java image variant (JDK 25 + Maven + Gradle + PlantUML)" };
 
     _mountOption = new Option<string[]>("--mount") { Description = "Mount directory (read-only). Format: path or host:container" };
 

--- a/docker/generated/Dockerfile.java
+++ b/docker/generated/Dockerfile.java
@@ -45,19 +45,19 @@ RUN ARCH=$(dpkg --print-architecture) \
   fi
 
 # --- snippet: java ---
-# Install Java (Eclipse Temurin JDK 21), Maven, and Gradle
+# Install Java (Eclipse Temurin JDK 25), Maven, and Gradle
 # Using Eclipse Temurin - widely used, well-maintained OpenJDK distribution
 
 # Add Eclipse Temurin repository and install JDK
 RUN apt-get update && apt-get install -y gnupg unzip \
   && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" > /etc/apt/sources.list.d/adoptium.list \
-  && apt-get update && apt-get install -y temurin-21-jdk \
+  && apt-get update && apt-get install -y temurin-25-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # Set JAVA_HOME dynamically based on architecture (ENV can't use command substitution)
-RUN ln -s /usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-21-jdk
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
+RUN ln -s /usr/lib/jvm/temurin-25-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-25-jdk
+ENV JAVA_HOME=/usr/lib/jvm/temurin-25-jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven

--- a/docker/snippets/java.Dockerfile
+++ b/docker/snippets/java.Dockerfile
@@ -1,16 +1,16 @@
-# Install Java (Eclipse Temurin JDK 21), Maven, and Gradle
+# Install Java (Eclipse Temurin JDK 25), Maven, and Gradle
 # Using Eclipse Temurin - widely used, well-maintained OpenJDK distribution
 
 # Add Eclipse Temurin repository and install JDK
 RUN apt-get update && apt-get install -y gnupg unzip \
   && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor -o /usr/share/keyrings/adoptium.gpg \
   && echo "deb [signed-by=/usr/share/keyrings/adoptium.gpg] https://packages.adoptium.net/artifactory/deb $(. /etc/os-release && echo $VERSION_CODENAME) main" > /etc/apt/sources.list.d/adoptium.list \
-  && apt-get update && apt-get install -y temurin-21-jdk \
+  && apt-get update && apt-get install -y temurin-25-jdk \
   && rm -rf /var/lib/apt/lists/*
 
 # Set JAVA_HOME dynamically based on architecture (ENV can't use command substitution)
-RUN ln -s /usr/lib/jvm/temurin-21-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-21-jdk
-ENV JAVA_HOME=/usr/lib/jvm/temurin-21-jdk
+RUN ln -s /usr/lib/jvm/temurin-25-jdk-$(dpkg --print-architecture) /usr/lib/jvm/temurin-25-jdk
+ENV JAVA_HOME=/usr/lib/jvm/temurin-25-jdk
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Install Maven

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -62,7 +62,7 @@ Extends the base image with:
 **Tag:** `ghcr.io/gordonbeeming/copilot_here:java`
 
 Extends the base image with:
-- Java JDK 21 (Eclipse Temurin)
+- Java JDK 25 (Eclipse Temurin)
 - Maven
 - Gradle
 - PlantUML (with Graphviz)


### PR DESCRIPTION
This commit updates the Java Development Kit (JDK) in the Docker images from version 21 to version 25. This is a minor update with little to no impact on existing functionality due to Java's backward compatibility.

The changes include:
*   Updating the `--java` option description in `app/Commands/Run/RunCommand.cs`.
*   Modifying `docker/snippets/java.Dockerfile` to install Eclipse Temurin JDK 25.
*   Updating `docs/docker-images.md` to reflect the new Java version.

#91