### PR TITLE
fix(ci): airlock smoke test runs on PRs and binds broker to IPAddress.Any

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -567,6 +567,48 @@ jobs:
         working-directory: tests/CopilotHere.IntegrationTests
         run: dotnet run --configuration Release
 
+  # Full airlock + DinD smoke test. Spins up a real airlock compose project,
+  # points the workload at the broker via the proxy bridge, and verifies that
+  # spawned siblings get the airlock NetworkMode injected via Phase 2 body
+  # inspection. This is the unblocker test from issue #20.
+  #
+  # Builds the proxy + default app images LOCALLY via dev-build.sh so the job
+  # can run on every PR without depending on the published ghcr tags (which
+  # are main-only). On the order of ~5 minutes for the image build, plus
+  # ~30 seconds for the test itself.
+  integration-tests-airlock:
+    name: Integration Tests (Airlock)
+    needs: [test-cli]
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
+        with:
+          global-json-file: global.json
+
+      - name: Pre-pull alpine (sibling target)
+        run: docker pull alpine:3.21
+
+      - name: Build proxy + default app images locally
+        run: |
+          chmod +x ./dev-build.sh
+          ./dev-build.sh
+
+      - name: Run integration tests (airlock + dind)
+        env:
+          RUN_LIVE_DOCKER_TESTS: "1"
+          # dev-build.sh tags the proxy as :proxy and the default app image
+          # as :latest / :copilot-latest. Point the smoke test at those
+          # local tags via the override env vars (the test skips when both
+          # are unset to avoid running against random pulls).
+          COPILOT_HERE_PROXY_IMAGE: ghcr.io/gordonbeeming/copilot_here:proxy
+          COPILOT_HERE_APP_IMAGE: ghcr.io/gordonbeeming/copilot_here:latest
+        working-directory: tests/CopilotHere.IntegrationTests
+        run: dotnet run --configuration Release
+
   # Compute version from VERSION file + run number as revision
   compute-version:
     name: Compute Version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -523,50 +523,6 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/${{ needs.prepare-versions.outputs.repo_name }}:copilot-${{ matrix.image }},mode=max
           cache-to: type=inline
 
-  # Full airlock + DinD smoke test using the freshly published proxy and
-  # default app images. This is the unblocker test from issue #20: it spins
-  # up a real airlock compose project, points the workload at the broker via
-  # the proxy bridge, and verifies that spawned siblings get the airlock
-  # NetworkMode injected via Phase 2 body inspection.
-  #
-  # Only runs on main because it depends on build-proxy and build-images
-  # having pushed the canonical sha-tagged images. PRs are covered by the
-  # cheaper integration-tests-broker job above.
-  integration-tests-airlock:
-    name: Integration Tests (Airlock)
-    needs: [build-proxy, build-images, prepare-versions]
-    runs-on: ubuntu-24.04
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
-        with:
-          global-json-file: global.json
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pre-pull test images
-        run: |
-          docker pull alpine:3.21
-          docker pull ghcr.io/${{ needs.prepare-versions.outputs.repo_name }}:proxy-sha-${{ github.sha }}
-          docker pull ghcr.io/${{ needs.prepare-versions.outputs.repo_name }}:copilot-default-sha-${{ github.sha }}
-
-      - name: Run integration tests (airlock + dind)
-        env:
-          RUN_LIVE_DOCKER_TESTS: "1"
-          COPILOT_HERE_PROXY_IMAGE: ghcr.io/${{ needs.prepare-versions.outputs.repo_name }}:proxy-sha-${{ github.sha }}
-          COPILOT_HERE_APP_IMAGE: ghcr.io/${{ needs.prepare-versions.outputs.repo_name }}:copilot-default-sha-${{ github.sha }}
-        working-directory: tests/CopilotHere.IntegrationTests
-        run: dotnet run --configuration Release
-
   # Full airlock + DinD smoke test. Spins up a real airlock compose project,
   # points the workload at the broker via the proxy bridge, and verifies that
   # spawned siblings get the airlock NetworkMode injected via Phase 2 body

--- a/tests/CopilotHere.IntegrationTests/AirlockSmokeTests.cs
+++ b/tests/CopilotHere.IntegrationTests/AirlockSmokeTests.cs
@@ -61,10 +61,16 @@ public class AirlockSmokeTests
     var projectName = $"copilot-airlock-it-{sessionId}";
     var logPath = Path.Combine(Path.GetTempPath(), $"airlock-broker-{sessionId}.jsonl");
 
+    // Bind to IPAddress.Any so the proxy container's socat bridge can reach
+    // the broker. The proxy container resolves host.docker.internal via
+    // host-gateway, which on Linux runners points at the docker bridge IP
+    // (e.g. 172.17.0.1) — a loopback-only listener can't accept connections
+    // from there. macOS / OrbStack would route loopback magically, Linux CI
+    // does not. Same fix as BrokerSmokeTests.
     await using var broker = new DockerSocketBroker(
       rules,
       hostSocket,
-      BrokerListenEndpoint.Tcp(IPAddress.Loopback, 0),
+      BrokerListenEndpoint.Tcp(IPAddress.Any, 0),
       logPath);
     await broker.StartAsync(CancellationToken.None);
 


### PR DESCRIPTION
## Summary

- `AirlockSmokeTests.cs` was still binding the broker to `IPAddress.Loopback`, which only works on macOS / Docker Desktop / OrbStack — Linux CI runners route `host.docker.internal:host-gateway` to the bridge IP and a loopback-only listener can't accept connections from there. Switch to `IPAddress.Any`, same fix already applied to `BrokerSmokeTests`.
- `integration-tests-airlock` was gated to `main` because it depended on `build-proxy` / `build-images` having pushed the canonical sha tags. Now it builds the proxy + default app images locally via `dev-build.sh` and runs on every PR. Catches airlock + DinD regressions at PR time instead of post-merge.

## Why this matters

The current main build is failing on this exact bug — the regression slipped past PRs because the airlock smoke test only ran on main. ([failing run](https://github.com/GordonBeeming/copilot_here/actions/runs/24171891941))

## Test plan

- [ ] CI: integration-tests-airlock runs and passes on this PR
- [ ] CI: integration-tests-broker stays green
- [ ] CI: every other check stays green
- [ ] Manual: 556/556 unit tests pass locally

Refs #20