### PR TITLE
feat: add Python pip & pipx to the base image (#121)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Choose your platform below. The scripts include both **Safe Mode** (asks for con
 All images support both **AMD64** (x86_64) and **ARM64** (Apple Silicon, etc.) architectures.
 
 All functions support switching between Docker image variants using flags:
-- **No flag** - Base image (Node.js, Git, basic tools)
+- **No flag** - Base image (Node.js, Python with pip & pipx, Git, basic tools)
 - **`--dotnet`** (`-d`) - .NET image (includes .NET 8, 9 & 10 SDKs)
 - **`--dotnet8`** (`-d8`) - .NET 8 image (includes .NET 8 SDK)
 - **`--dotnet9`** (`-d9`) - .NET 9 image (includes .NET 9 SDK)
@@ -669,7 +669,7 @@ This project provides multiple Docker image variants for different development s
 
 | Tag | Flag | Description |
 |-----|------|-------------|
-| `latest` | *(default)* | Base image with Node.js 20, Git, and essential tools |
+| `latest` | *(default)* | Base image with Node.js 20, Python (pip & pipx), Git, and essential tools |
 | `dotnet` | `--dotnet` | .NET 8, 9 & 10 SDKs |
 | `dotnet-8` | `--dotnet8` | .NET 8 SDK only |
 | `dotnet-9` | `--dotnet9` | .NET 9 SDK only |

--- a/docker/generated/Dockerfile.default
+++ b/docker/generated/Dockerfile.default
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.default
+++ b/docker/generated/Dockerfile.default
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.default
+++ b/docker/generated/Dockerfile.default
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet
+++ b/docker/generated/Dockerfile.dotnet
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet
+++ b/docker/generated/Dockerfile.dotnet
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet
+++ b/docker/generated/Dockerfile.dotnet
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-10
+++ b/docker/generated/Dockerfile.dotnet-10
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet-10
+++ b/docker/generated/Dockerfile.dotnet-10
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-10
+++ b/docker/generated/Dockerfile.dotnet-10
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-8
+++ b/docker/generated/Dockerfile.dotnet-8
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet-8
+++ b/docker/generated/Dockerfile.dotnet-8
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-8
+++ b/docker/generated/Dockerfile.dotnet-8
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-9
+++ b/docker/generated/Dockerfile.dotnet-9
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet-9
+++ b/docker/generated/Dockerfile.dotnet-9
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-9
+++ b/docker/generated/Dockerfile.dotnet-9
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-playwright
+++ b/docker/generated/Dockerfile.dotnet-playwright
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet-playwright
+++ b/docker/generated/Dockerfile.dotnet-playwright
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-playwright
+++ b/docker/generated/Dockerfile.dotnet-playwright
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-rust
+++ b/docker/generated/Dockerfile.dotnet-rust
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.dotnet-rust
+++ b/docker/generated/Dockerfile.dotnet-rust
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.dotnet-rust
+++ b/docker/generated/Dockerfile.dotnet-rust
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.golang
+++ b/docker/generated/Dockerfile.golang
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.golang
+++ b/docker/generated/Dockerfile.golang
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.golang
+++ b/docker/generated/Dockerfile.golang
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.java
+++ b/docker/generated/Dockerfile.java
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.java
+++ b/docker/generated/Dockerfile.java
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.java
+++ b/docker/generated/Dockerfile.java
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.playwright
+++ b/docker/generated/Dockerfile.playwright
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.playwright
+++ b/docker/generated/Dockerfile.playwright
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.playwright
+++ b/docker/generated/Dockerfile.playwright
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.rust
+++ b/docker/generated/Dockerfile.rust
@@ -10,6 +10,8 @@ FROM node:20-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -17,11 +19,23 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---
 # Install Docker CLI to support brokered Docker socket scenarios.

--- a/docker/generated/Dockerfile.rust
+++ b/docker/generated/Dockerfile.rust
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -34,7 +35,7 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/generated/Dockerfile.rust
+++ b/docker/generated/Dockerfile.rust
@@ -29,13 +29,18 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh
 
 # --- snippet: docker-cli ---

--- a/docker/snippets/system-packages.Dockerfile
+++ b/docker/snippets/system-packages.Dockerfile
@@ -21,11 +21,16 @@ RUN apt-get update && apt-get install -y \
   zsh \
   && rm -rf /var/lib/apt/lists/*
 
-# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
-# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
-# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# pipx installs apps into the runtime user's ~/.local/bin, so that dir needs to be on PATH
+# for pipx-installed CLIs (e.g. `pipx install apm`) to be reachable without a per-session
+# `pipx ensurepath`. The entrypoint always runs as appuser with HOME=/home/appuser.
+# Append (not prepend): the entrypoint runs as root and resolves tools like getent/groupadd/
+# node via PATH before dropping to appuser, so a system binary must always win over anything
+# in the user-writable (and possibly bind-mounted) ~/.local/bin — otherwise a planted binary
+# there could execute as root. Appending keeps pipx apps reachable while system paths stay
+# authoritative; pipx app names don't collide with system binaries.
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
-ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
+ENV PATH="${PATH}:/home/appuser/.local/bin"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="${PATH:+${PATH}:}/home/appuser/.local/bin" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh

--- a/docker/snippets/system-packages.Dockerfile
+++ b/docker/snippets/system-packages.Dockerfile
@@ -2,6 +2,8 @@
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install git, curl, gpg, gosu, nano, xdg-utils, zsh, and related utilities for the entrypoint script and testing.
+# Python tooling (pip + venv + pipx) ships here so every image can install pip-distributed
+# CLIs; Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path.
 RUN apt-get update && apt-get install -y \
   apt-transport-https \
   curl \
@@ -9,8 +11,20 @@ RUN apt-get update && apt-get install -y \
   gosu \
   gpg \
   nano \
+  pipx \
+  python3-pip \
+  python3-venv \
   software-properties-common \
   wget \
   xdg-utils \
   zsh \
   && rm -rf /var/lib/apt/lists/*
+
+# pipx installs apps into the runtime user's ~/.local/bin. The entrypoint always runs as
+# appuser with HOME=/home/appuser, so put that dir on PATH up front and pipx-installed CLIs
+# (e.g. `pipx install apm`) are reachable without a per-session `pipx ensurepath`.
+# ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
+# login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
+ENV PATH="/home/appuser/.local/bin:${PATH}"
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+  > /etc/profile.d/copilot-local-bin.sh

--- a/docker/snippets/system-packages.Dockerfile
+++ b/docker/snippets/system-packages.Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
   gpg \
   nano \
   pipx \
+  python3 \
   python3-pip \
   python3-venv \
   software-properties-common \
@@ -26,5 +27,5 @@ RUN apt-get update && apt-get install -y \
 # ENV covers the exec'd command and non-login shells; the profile.d drop-in re-adds it for
 # login shells, which otherwise reset PATH via /etc/profile (Debian zsh sources it too).
 ENV PATH="/home/appuser/.local/bin:${PATH}"
-RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin:${PATH}" ;; esac' \
+RUN echo 'case ":${PATH}:" in *:/home/appuser/.local/bin:*) ;; *) PATH="/home/appuser/.local/bin${PATH:+:${PATH}}" ;; esac' \
   > /etc/profile.d/copilot-local-bin.sh

--- a/docs/docker-images.md
+++ b/docs/docker-images.md
@@ -7,6 +7,7 @@ This repository publishes multiple Docker image variants to optimize for size an
 
 The standard copilot_here image with:
 - Node.js 20
+- Python 3 with pip & pipx (Debian 12 enforces PEP 668, so `pipx install <tool>` is the supported path for pip-distributed CLIs)
 - GitHub Copilot CLI
 - Git, curl, gpg, gosu
 


### PR DESCRIPTION
Closes #121.

## What

`python3` was already present in the images (pulled in transitively by `software-properties-common`), but there was no `pip`, so pip-distributed CLIs like APM couldn't be installed. This adds `python3-pip`, `python3-venv` and `pipx` to the shared `system-packages` snippet, so every image variant gets them in one place.

## Why pipx + PATH

The base is Debian 12 (bookworm), which enforces PEP 668 — a bare `pip install <tool>` fails with `externally-managed-environment`. `pipx` is the supported way to install CLI apps (it drops each into its own venv); `pip` still works inside venvs.

pipx installs to `~/.local/bin`, which isn't on PATH by default. Since the entrypoint always runs as `appuser` with `HOME=/home/appuser`, I put that dir on PATH two ways so it's reachable everywhere:

- `ENV PATH=...` — covers the exec'd run command and non-login shells.
- `/etc/profile.d/copilot-local-bin.sh` — re-adds it for login shells, which otherwise reset PATH via `/etc/profile` (Debian zsh sources it too).

End result: `pipx install apm` then `apm` just works, no `pipx ensurepath` needed.

## Changes

- `docker/snippets/system-packages.Dockerfile` — add the three packages + PATH wiring.
- Regenerated `docker/generated/*` (copilot variants). The `claude-*` variants live on the still-open #120 branch; their regen lands when the branches combine (CI auto-regenerates Dockerfiles).
- `README.md` + `docs/docker-images.md` — note Python/pip/pipx in the base image.

## Test plan

Built `Dockerfile.default` and verified:

```
$ python3 --version   # Python 3.11.2
$ pip --version       # pip 23.0.1
$ pipx --version      # 1.1.0
$ pipx install apm && command -v apm   # /home/appuser/.local/bin/apm
```

Confirmed `apm` is on PATH in `bash -lc`, `zsh -lc`, and non-login shells. `pwsh docker/verify-generated.ps1` reports the generated Dockerfiles are up to date.

Note: the PyPI package literally named `apm` (v0.0.1) is ancient Python-2 code and unrelated to the issue author's "Agent Package Manager" — confirming the package name is up to the user. This PR's job is making pip/pipx available, which is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)