### PR TITLE
fix: rootless Podman can't write bind-mounted host files (#119)

### DIFF
--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -599,7 +599,8 @@ public sealed class RunCommand : ICommand
         // Build Docker args for standard mode
         var sessionId = GenerateSessionId();
         var containerName = $"copilot_here-{sessionId}";
-        var dockerArgs = BuildDockerArgs(ctx, imageName, containerName, allMounts, toolCommand, _isYolo, imageTag, noPull, broker);
+        var rootlessPodman = ContainerRuntimeConfig.IsRootlessPodman(ctx.RuntimeConfig);
+        var dockerArgs = BuildDockerArgs(ctx, imageName, containerName, allMounts, toolCommand, _isYolo, imageTag, noPull, broker, rootlessPodman);
         DebugLogger.Log($"docker args: {string.Join(" | ", dockerArgs.Select(a => a.Length > 80 ? a[..80] + "..." : a))}");
 
         // Set terminal title
@@ -791,7 +792,8 @@ public sealed class RunCommand : ICommand
     bool isYolo,
     string imageTag,
     bool noPull,
-    DockerSocketBroker? broker)
+    DockerSocketBroker? broker,
+    bool rootlessPodman = false)
   {
     // Generate session info JSON
     var sessionInfo = SessionInfo.Generate(ctx, imageTag, imageName, mounts, isYolo);
@@ -869,6 +871,19 @@ public sealed class RunCommand : ICommand
     {
       DebugLogger.Log($"Adding {sandboxFlags.Count} sandbox flags from SANDBOX_FLAGS");
       args.AddRange(sandboxFlags);
+    }
+
+    // Rootless Podman maps the host user to container root, so bind-mounted host
+    // files land as root-owned and the workload's appuser can't write them.
+    // keep-id remaps the host UID/GID to the same values inside the container so
+    // appuser (PUID/PGID) owns the mounts. We still start as root (--user 0:0) so
+    // the entrypoint can run useradd/chown before gosu-dropping to appuser.
+    if (rootlessPodman)
+    {
+      args.Add("--user");
+      args.Add("0:0");
+      args.Add("--userns");
+      args.Add($"keep-id:uid={ctx.Environment.UserId},gid={ctx.Environment.GroupId}");
     }
 
     // Add image name

--- a/app/Infrastructure/AirlockRunner.cs
+++ b/app/Infrastructure/AirlockRunner.cs
@@ -146,9 +146,11 @@ public static class AirlockRunner
     SetupLogsDirectory(ctx.Paths, rulesPath);
 
     // Generate compose file
+    var rootlessPodman = ContainerRuntimeConfig.IsRootlessPodman(runtimeConfig);
     var composeFile = GenerateComposeFile(
       runtimeConfig, ctx, templateContent, projectName, appImage, proxyImage,
-      processedConfigPath, externalNetwork, appFlags, mounts, toolArgs, imageTag, isYolo, broker);
+      processedConfigPath, externalNetwork, appFlags, mounts, toolArgs, imageTag, isYolo, broker,
+      rootlessPodman);
 
     if (composeFile is null)
     {
@@ -329,7 +331,8 @@ public static class AirlockRunner
     List<string> toolArgs,
     string imageTag,
     bool isYolo,
-    DockerSocketBroker? broker)
+    DockerSocketBroker? broker,
+    bool rootlessPodman = false)
   {
     try
     {
@@ -401,6 +404,18 @@ public static class AirlockRunner
         }
         brokerEnv.Append("      - TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal");
         brokerExtraHosts.Append("    extra_hosts:\n      - \"host.docker.internal:host-gateway\"");
+      }
+
+      // Rootless Podman maps the host user to container root, so bind-mounted
+      // host files land as root-owned and the workload's appuser can't write
+      // them. keep-id remaps the host UID/GID to the same values inside the
+      // container; user 0:0 keeps the entrypoint running as root so it can run
+      // useradd/chown before gosu-dropping to appuser. Empty otherwise.
+      var usernsBlock = new StringBuilder();
+      if (rootlessPodman)
+      {
+        usernsBlock.AppendLine("    user: \"0:0\"");
+        usernsBlock.Append($"    userns_mode: \"keep-id:uid={ctx.Environment.UserId},gid={ctx.Environment.GroupId}\"");
       }
 
       // Build logs mount if logging enabled
@@ -495,6 +510,13 @@ public static class AirlockRunner
         {
           if (extraMounts.Length > 0)
             lines[i] = extraMounts.ToString().TrimEnd();
+          else
+            lines.RemoveAt(i);
+        }
+        else if (lines[i].Contains("{{USERNS}}"))
+        {
+          if (usernsBlock.Length > 0)
+            lines[i] = usernsBlock.ToString().TrimEnd();
           else
             lines.RemoveAt(i);
         }

--- a/app/Infrastructure/ContainerRuntimeConfig.cs
+++ b/app/Infrastructure/ContainerRuntimeConfig.cs
@@ -438,6 +438,42 @@ public sealed record ContainerRuntimeConfig
     return File.Exists(path);
   }
 
+  /// <summary>
+  /// Reports whether the active runtime is rootless Podman.
+  /// Only rootless Podman needs the keep-id user-namespace remap: its default
+  /// userns maps the host user to container root, so bind-mounted host files
+  /// appear root-owned and the workload's non-root appuser can't write them.
+  /// Docker/OrbStack/Podman-Machine show the real host UID and need no remap;
+  /// rootful Podman rejects keep-id outright. Any detection failure → false.
+  /// </summary>
+  public static bool IsRootlessPodman(ContainerRuntimeConfig config)
+  {
+    if (config.Runtime != "podman")
+      return false;
+
+    try
+    {
+      var startInfo = new ProcessStartInfo("podman", "info --format {{.Host.Security.Rootless}}")
+      {
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        CreateNoWindow = true
+      };
+      using var process = Process.Start(startInfo);
+      if (process is null) return false;
+
+      var output = process.StandardOutput.ReadToEnd().Trim();
+      process.WaitForExit();
+      return process.ExitCode == 0
+        && string.Equals(output, "true", StringComparison.OrdinalIgnoreCase);
+    }
+    catch
+    {
+      return false;
+    }
+  }
+
   private static string? TryGetPodmanSocketFromCli()
   {
     try

--- a/app/Infrastructure/ContainerRuntimeConfig.cs
+++ b/app/Infrastructure/ContainerRuntimeConfig.cs
@@ -463,8 +463,16 @@ public sealed record ContainerRuntimeConfig
       using var process = Process.Start(startInfo);
       if (process is null) return false;
 
+      // Bound the wait so an unresponsive Podman VM can't hang the CLI. The
+      // output is a single token, well under the pipe buffer, so waiting before
+      // reading can't deadlock on a full stdout buffer.
+      if (!process.WaitForExit(5000))
+      {
+        try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+        return false;
+      }
+
       var output = process.StandardOutput.ReadToEnd().Trim();
-      process.WaitForExit();
       return process.ExitCode == 0
         && string.Equals(output, "true", StringComparison.OrdinalIgnoreCase);
     }

--- a/app/Resources/docker-compose.airlock.yml.template
+++ b/app/Resources/docker-compose.airlock.yml.template
@@ -35,6 +35,7 @@ services:
   app:
     image: {{APP_IMAGE}}
     container_name: "{{PROJECT_NAME}}-app"
+{{USERNS}}
     networks:
       - airlock  # ONLY on airlock - cannot reach external network directly
     environment:

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -30,6 +30,10 @@ The `--dind` flag enables Testcontainers and sibling-container workflows by rout
 - **OrbStack:** Works without configuration. OrbStack exposes the standard `/var/run/docker.sock` on macOS, so the broker connects to it the same way as Docker Desktop.
 - **DinD + airlock (macOS / Windows):** The Docker API path works (workload → `proxy:2375` → socat → host broker), and sibling containers are created on the airlock compose network. However, **Testcontainers data-plane connections fail**: the workload sets `TESTCONTAINERS_HOST_OVERRIDE=host.docker.internal`, but `host.docker.internal` is unreachable via raw TCP from the `internal: true` airlock network. Testcontainers tries to connect to `<host>:<random_mapped_port>` and times out. **Workaround:** use `--dind` without `--airlock` until a fix lands. See [#101](https://github.com/GordonBeeming/copilot_here/issues/101) for potential solutions and discussion.
 
+## Rootless Podman file ownership
+
+- **Rootless Podman can't write bind-mounted host files — fixed automatically.** Rootless Podman runs inside a user namespace that maps your host user to `root` inside the container. A bind-mounted file you own on the host therefore shows up as `root`-owned inside, while the workload runs as `appuser` (your host UID, which maps to a subordinate UID). The result: `appuser` can't write the files you mounted in, so the CLI tool fails to make changes. See [#119](https://github.com/GordonBeeming/copilot_here/issues/119). `copilot_here` detects rootless Podman via `podman info --format '{{.Host.Security.Rootless}}'` and adds `--userns=keep-id:uid=<PUID>,gid=<PGID>` (plus `--user 0:0` so the entrypoint still starts as root for its user setup). keep-id maps your host UID/GID to the same values inside the container, so the mounts show up owned by `appuser` and stay writable. Docker, OrbStack, and Podman Machine already expose the real host UID, so they're left untouched; rootful Podman is skipped because keep-id is rootless-only.
+
 ## Reporting New Issues
 
 Found a new issue? Please report it on our [GitHub Issues](https://github.com/GordonBeeming/copilot_here/issues) page with:

--- a/tests/CopilotHere.UnitTests/AirlockComposeDindTests.cs
+++ b/tests/CopilotHere.UnitTests/AirlockComposeDindTests.cs
@@ -55,7 +55,7 @@ public class AirlockComposeDindTests
       Directory.Delete(_tempDir, recursive: true);
   }
 
-  private string GenerateCompose(DockerSocketBroker? broker)
+  private string GenerateCompose(DockerSocketBroker? broker, bool rootlessPodman = false)
   {
     var ctx = AppContext.Create();
     var runtimeConfig = ContainerRuntimeConfig.CreateConfig("docker");
@@ -79,7 +79,8 @@ public class AirlockComposeDindTests
       toolArgs: ["copilot"],
       imageTag: "latest",
       isYolo: false,
-      broker: broker)
+      broker: broker,
+      rootlessPodman: rootlessPodman)
       ?? throw new InvalidOperationException("GenerateComposeFile returned null");
 
     var content = File.ReadAllText(composePath);
@@ -171,5 +172,29 @@ public class AirlockComposeDindTests
     // No raw placeholders left over.
     await Assert.That(content).DoesNotContain("{{PROXY_BROKER_ENV}}");
     await Assert.That(content).DoesNotContain("{{PROXY_BROKER_EXTRA_HOSTS}}");
+  }
+
+  [Test]
+  public async Task GenerateComposeFile_NotRootless_RemovesUsernsPlaceholder()
+  {
+    var content = GenerateCompose(broker: null);
+
+    await Assert.That(content).DoesNotContain("{{USERNS}}");
+    await Assert.That(content).DoesNotContain("userns_mode");
+    await Assert.That(content).DoesNotContain("keep-id");
+  }
+
+  [Test]
+  public async Task GenerateComposeFile_RootlessPodman_AddsKeepIdUserns()
+  {
+    // #119: keep-id remaps the host UID/GID into the rootless-Podman container so
+    // appuser owns the bind mounts; user 0:0 keeps the entrypoint running as root.
+    var ctx = AppContext.Create();
+    var content = GenerateCompose(broker: null, rootlessPodman: true);
+
+    await Assert.That(content).DoesNotContain("{{USERNS}}");
+    await Assert.That(content).Contains("user: \"0:0\"");
+    await Assert.That(content)
+      .Contains($"userns_mode: \"keep-id:uid={ctx.Environment.UserId},gid={ctx.Environment.GroupId}\"");
   }
 }

--- a/tests/CopilotHere.UnitTests/DindArgsTests.cs
+++ b/tests/CopilotHere.UnitTests/DindArgsTests.cs
@@ -222,4 +222,38 @@ public class DindArgsTests
     await Assert.That(hostIdx).IsGreaterThanOrEqualTo(0);
     await Assert.That(args[hostIdx - 1]).IsEqualTo("--add-host");
   }
+
+  [Test]
+  public async Task BuildDockerArgs_RootlessPodman_AddsKeepIdUserns()
+  {
+    // #119: rootless Podman maps the host user to container root, so bind mounts
+    // land root-owned and appuser can't write them. keep-id remaps the host
+    // UID/GID into the container; --user 0:0 keeps the entrypoint running as root.
+    var ctx = AppContext.Create();
+    var args = RunCommand.BuildDockerArgs(
+      ctx, "img", "name", [], ["copilot"], false, "latest", false, broker: null,
+      rootlessPodman: true);
+
+    var usernsIdx = args.FindIndex(a => a == "--userns");
+    await Assert.That(usernsIdx).IsGreaterThanOrEqualTo(0);
+    await Assert.That(args[usernsIdx + 1])
+      .IsEqualTo($"keep-id:uid={ctx.Environment.UserId},gid={ctx.Environment.GroupId}");
+
+    var userIdx = args.FindIndex(a => a == "--user");
+    await Assert.That(userIdx).IsGreaterThanOrEqualTo(0);
+    await Assert.That(args[userIdx + 1]).IsEqualTo("0:0");
+  }
+
+  [Test]
+  public async Task BuildDockerArgs_NotRootless_NoUserns()
+  {
+    // Docker / OrbStack / Podman Machine / rootful Podman: no keep-id remap.
+    var ctx = AppContext.Create();
+    var args = RunCommand.BuildDockerArgs(
+      ctx, "img", "name", [], ["copilot"], false, "latest", false, broker: null);
+
+    var joined = string.Join(" ", args);
+    await Assert.That(joined).DoesNotContain("--userns");
+    await Assert.That(joined).DoesNotContain("keep-id");
+  }
 }

--- a/tests/integration/test_airlock.sh
+++ b/tests/integration/test_airlock.sh
@@ -324,6 +324,10 @@ EOF
         gsub(/\{\{LOGS_MOUNT\}\}/, logs_mount);
         gsub(/\{\{PUID\}\}/, puid);
         gsub(/\{\{PGID\}\}/, pgid);
+        # User-namespace remap (rootless Podman keep-id). The integration test
+        # runs under Docker, so this stays empty and the line collapses to a
+        # blank line, which docker compose tolerates.
+        gsub(/\{\{USERNS\}\}/, "");
         gsub(/\{\{EXTRA_MOUNTS\}\}/, extra_mounts);
         gsub(/\{\{EXTRA_SANDBOX_FLAGS\}\}/, extra_sandbox_flags);
         gsub(/\{\{TOOL_ARGS\}\}/, copilot_args);


### PR DESCRIPTION
## Problem

Under rootless Podman, the CLI tool can't change any of your files. Closes #119.

Rootless Podman runs inside a user namespace that maps your host user to `root` inside the container. So a file you own on the host shows up as `root`-owned inside, while the workload runs as `appuser` (your host UID, which maps to a subordinate UID, not back to you). `appuser` then can't write the files you bind-mounted in, and the tool's edits fail with permission errors.

Docker, OrbStack, and Podman Machine don't hit this because they expose the real host UID inside the container, so `appuser` already owns the mounts.

## Fix

Detect rootless Podman via `podman info --format '{{.Host.Security.Rootless}}'` and, only then, add to the `run` invocation:

- `--userns=keep-id:uid=<PUID>,gid=<PGID>` — maps your host UID/GID to the same values inside the container, so the mounts come through owned by `appuser` and stay writable. Files it creates come back owned by you on the host.
- `--user 0:0` — keeps the entrypoint starting as root so it can still run its `useradd`/`chown` setup before `gosu`-dropping to `appuser`.

The same treatment is wired into the airlock compose template through a new `{{USERNS}}` block (`user:` + `userns_mode:`), filled only for rootless Podman.

Detection lives in `ContainerRuntimeConfig.IsRootlessPodman` and returns `false` on any failure, so a stopped machine or a non-podman runtime is safe. Rootful Podman is skipped because `keep-id` is rootless-only; Docker/OrbStack/Podman Machine are untouched.

No entrypoint or Dockerfile changes — the existing root-then-`gosu` flow is preserved, so the generated images don't need regenerating.

## Test plan

- `dotnet test` — 616 unit tests pass, including new cases:
  - `BuildDockerArgs_RootlessPodman_AddsKeepIdUserns` / `BuildDockerArgs_NotRootless_NoUserns` (standard mode args)
  - `GenerateComposeFile_RootlessPodman_AddsKeepIdUserns` / `GenerateComposeFile_NotRootless_RemovesUsernsPlaceholder` (airlock compose)
- Confirmed `IsRootlessPodman` returns `false` on this macOS box (Podman Machine stopped → `podman info` errors → safe default), so Docker/OrbStack/Podman Machine runs are unchanged.
- End-to-end on Linux rootless Podman still needs a live run: `--set-runtime podman`, edit a tracked file from inside, exit, confirm the change landed on the host and is still owned by you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)