### PR TITLE
feat: add a proper uninstall for copilot_here

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -112,7 +112,9 @@ jobs:
 
       - name: Test Bash script syntax
         if: runner.os != 'Windows'
-        run: bash -n copilot_here.sh
+        run: |
+          bash -n copilot_here.sh
+          bash -n uninstall.sh
 
       - name: Test Bash source and copilot_here --help
         if: runner.os != 'Windows'
@@ -155,6 +157,12 @@ jobs:
           $null = [System.Management.Automation.Language.Parser]::ParseFile("$PWD/copilot_here.ps1", [ref]$null, [ref]$errors)
           if ($errors.Count -gt 0) {
             $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+          $uninstallErrors = $null
+          $null = [System.Management.Automation.Language.Parser]::ParseFile("$PWD/uninstall.ps1", [ref]$null, [ref]$uninstallErrors)
+          if ($uninstallErrors.Count -gt 0) {
+            $uninstallErrors | ForEach-Object { Write-Error $_.Message }
             exit 1
           }
           Write-Host "✓ PowerShell syntax is valid"
@@ -811,6 +819,8 @@ jobs:
           cp copilot_here.ps1 release/
           cp install.sh release/
           cp install.ps1 release/
+          cp uninstall.sh release/
+          cp uninstall.ps1 release/
 
           ls -la release/
 

--- a/README.md
+++ b/README.md
@@ -559,6 +559,58 @@ If you prefer not to use the quick install method, you can manually copy the scr
 
 
 
+## 🧹 Uninstalling
+
+No digging through the install script to figure out what to undo. Pick whichever method matches how you installed.
+
+### Quick (if the CLI still works)
+
+```bash
+copilot_here --uninstall
+```
+
+That removes the binary, the sourced script, and the shell integration from your profiles, and stops any running containers. Your config and pulled Docker images stay put. To wipe those too:
+
+```bash
+copilot_here --uninstall --purge   # also deletes config dirs + pulled images
+```
+
+Add `--yes` to skip the confirmation prompt. The uninstall never touches `~/.claude`, your real Claude Code config.
+
+### Remote script (if the install is broken or already half-gone)
+
+Self-contained, so it cleans up even when the binary won't run.
+
+**Linux/macOS (Bash/Zsh):**
+
+```bash
+bash <(curl -fsSL https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.sh)
+# add --purge to also delete config dirs, --yes to skip the prompt
+```
+
+**Windows (PowerShell):**
+
+```powershell
+& ([scriptblock]::Create((iwr -UseBasicParsing 'https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.ps1').Content))
+# add -Purge to also delete config dirs, -Yes to skip the prompt
+```
+
+### Installed via a package manager?
+
+Remove it the same way you added it:
+
+```bash
+brew uninstall --cask copilot-here      # Homebrew (macOS)
+brew uninstall copilot_here             # Homebrew (Linux)
+winget uninstall GordonBeeming.CopilotHere   # WinGet (Windows)
+dotnet tool uninstall -g copilot_here   # .NET global tool
+```
+
+For the full list of every file and directory the install touches — handy if you'd rather remove things by hand — see [docs/uninstall.md](docs/uninstall.md).
+
+
+
+
 ## Usage
 
 Once set up, using it is simple on any platform. All commands work identically on Linux, macOS, and Windows.

--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -52,6 +52,11 @@ public sealed class RunCommand : ICommand
   // === SHELL INTEGRATION INSTALL (handled by native binary) ===
   private readonly Option<bool> _installShellsOption;
 
+  // === UNINSTALL (handled by native binary) ===
+  private readonly Option<bool> _uninstallOption;
+  private readonly Option<bool> _purgeOption;
+  private readonly Option<bool> _yesOption;
+
   // === YOLO MODE (handled in Program.cs but shown in help) ===
   private readonly Option<bool> _yoloOption;
 
@@ -127,6 +132,11 @@ public sealed class RunCommand : ICommand
 
     _installShellsOption = new Option<bool>("--install-shells") { Description = "Install shell integrations (bash/zsh/fish + PowerShell/cmd)" };
 
+    _uninstallOption = new Option<bool>("--uninstall") { Description = "Remove copilot_here (binary, scripts, shell integration). Add --purge to also delete config and pulled images" };
+    _purgeOption = new Option<bool>("--purge") { Description = "With --uninstall: also delete config dirs and pulled Docker images (never touches ~/.claude)" };
+    _yesOption = new Option<bool>("--yes") { Description = "Skip confirmation prompts (for --uninstall)" };
+    _yesOption.Aliases.Add("-y");
+
     // Yolo mode - passes --yolo to Copilot (equivalent to --allow-all-tools --allow-all-paths --allow-all-urls)
     // Note: This is handled in Program.cs for app name, but we add it here so it shows in --help
     _yoloOption = new Option<bool>("--yolo") { Description = "Enable YOLO mode (allow all tools, paths, and URLs)" };
@@ -179,6 +189,9 @@ public sealed class RunCommand : ICommand
     root.Add(_help2Option);
     root.Add(_updateScriptsOption);
     root.Add(_installShellsOption);
+    root.Add(_uninstallOption);
+    root.Add(_purgeOption);
+    root.Add(_yesOption);
     root.Add(_yoloOption);
 
     // Copilot passthrough options
@@ -236,6 +249,9 @@ public sealed class RunCommand : ICommand
       var help2 = parseResult.GetValue(_help2Option);
       var updateScripts = parseResult.GetValue(_updateScriptsOption);
       var installShells = parseResult.GetValue(_installShellsOption);
+      var uninstall = parseResult.GetValue(_uninstallOption);
+      var purge = parseResult.GetValue(_purgeOption);
+      var assumeYes = parseResult.GetValue(_yesOption);
 
       // Copilot passthrough options
       var prompt = parseResult.GetValue(_promptOption);
@@ -260,6 +276,13 @@ public sealed class RunCommand : ICommand
       {
         DebugLogger.Log("--install-shells flag detected");
         return ShellIntegration.InstallAll();
+      }
+
+      // Handle --uninstall
+      if (uninstall)
+      {
+        DebugLogger.Log($"--uninstall flag detected (purge={purge}, yes={assumeYes})");
+        return RunUninstall(purge, assumeYes, ctx.RuntimeConfig);
       }
 
       // Handle --update - show message that it's handled by shell wrapper
@@ -992,6 +1015,88 @@ public sealed class RunCommand : ICommand
     
     // Remove trailing slashes/backslashes
     return path.TrimEnd('/', '\\');
+  }
+
+  /// <summary>
+  /// Removes copilot_here from the machine: confirms (unless assumeYes), delegates the
+  /// file/shell-integration removal to <see cref="ShellIntegration.UninstallAll"/>, and
+  /// — when purge is set — stops/removes copilot_here containers and pulled images.
+  /// </summary>
+  private static int RunUninstall(bool purge, bool assumeYes, ContainerRuntimeConfig runtimeConfig)
+  {
+    if (!assumeYes && !Console.IsInputRedirected && !Console.IsOutputRedirected)
+    {
+      Console.WriteLine("⚠️  This removes the copilot_here binary, scripts, and shell integration.");
+      if (purge)
+      {
+        Console.WriteLine("   --purge will also delete config (~/.config/copilot_here, ~/.config/copilot-cli-docker)");
+        Console.WriteLine("   and stop/remove copilot_here containers and pulled images.");
+      }
+      Console.Write("   Continue? [y/N]: ");
+      var response = Console.ReadLine()?.Trim().ToLowerInvariant();
+      if (response is not ("y" or "yes"))
+      {
+        Console.WriteLine("❌ Uninstall cancelled.");
+        return 1;
+      }
+    }
+
+    if (purge)
+    {
+      PurgeContainersAndImages(runtimeConfig);
+    }
+
+    return ShellIntegration.UninstallAll(purge);
+  }
+
+  /// <summary>
+  /// Best-effort removal of running copilot_here containers and pulled images. Never
+  /// throws: if the container runtime is missing or a command fails, it is reported
+  /// and skipped so the rest of the uninstall still completes.
+  /// </summary>
+  private static void PurgeContainersAndImages(ContainerRuntimeConfig runtimeConfig)
+  {
+    if (!ContainerRuntimeConfig.IsCommandAvailable(runtimeConfig.Runtime))
+    {
+      Console.WriteLine($"• Skipped container/image cleanup ({runtimeConfig.Runtime} not available)");
+      return;
+    }
+
+    try
+    {
+      // Stop and remove containers named copilot_here-*.
+      var (psCode, psOut, _) = ContainerRunner.RunAndCapture(
+        runtimeConfig, ["ps", "-aq", "--filter", "name=copilot_here-"]);
+      if (psCode == 0)
+      {
+        var ids = psOut.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (ids.Length > 0)
+        {
+          ContainerRunner.RunAndCapture(runtimeConfig, ["rm", "-f", .. ids]);
+          Console.WriteLine($"✓ Removed {ids.Length} copilot_here container(s)");
+        }
+      }
+
+      // Remove pulled images whose reference starts with the copilot_here prefix.
+      var (imgCode, imgOut, _) = ContainerRunner.RunAndCapture(
+        runtimeConfig, ["images", "--format", "{{.Repository}}:{{.Tag}}"]);
+      if (imgCode == 0)
+      {
+        var images = imgOut
+          .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+          .Where(r => r.StartsWith(ContainerRunner.ImagePrefix, StringComparison.Ordinal))
+          .ToArray();
+        if (images.Length > 0)
+        {
+          ContainerRunner.RunAndCapture(runtimeConfig, ["rmi", "-f", .. images]);
+          Console.WriteLine($"✓ Removed {images.Length} copilot_here image(s)");
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"• Container/image cleanup skipped: {ex.Message}");
+    }
   }
 
   /// <summary>

--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -1024,8 +1024,18 @@ public sealed class RunCommand : ICommand
   /// </summary>
   private static int RunUninstall(bool purge, bool assumeYes, ContainerRuntimeConfig runtimeConfig)
   {
-    if (!assumeYes && !Console.IsInputRedirected && !Console.IsOutputRedirected)
+    if (!assumeYes)
     {
+      // Destructive op: never proceed without an explicit acknowledgement. In a
+      // non-interactive context (piped/redirected stdio, CI) we can't reliably read
+      // a prompt, so refuse and require --yes rather than silently uninstalling.
+      if (Console.IsInputRedirected || Console.IsOutputRedirected)
+      {
+        Console.Error.WriteLine("❌ Refusing to uninstall non-interactively without confirmation.");
+        Console.Error.WriteLine("   Re-run with --yes to confirm: copilot_here --uninstall --yes");
+        return 1;
+      }
+
       Console.WriteLine("⚠️  This removes the copilot_here binary, scripts, and shell integration.");
       if (purge)
       {

--- a/app/Infrastructure/ContainerRunner.cs
+++ b/app/Infrastructure/ContainerRunner.cs
@@ -7,7 +7,8 @@ namespace CopilotHere.Infrastructure;
 /// </summary>
 public static class ContainerRunner
 {
-  private const string ImagePrefix = "ghcr.io/gordonbeeming/copilot_here";
+  /// <summary>Registry/repository prefix for all official copilot_here images.</summary>
+  public const string ImagePrefix = "ghcr.io/gordonbeeming/copilot_here";
 
   /// <summary>
   /// Gets the full image name for a given tag.

--- a/app/Infrastructure/ShellIntegration.cs
+++ b/app/Infrastructure/ShellIntegration.cs
@@ -223,13 +223,26 @@ public static class ShellIntegration
     var newline = original.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
     var lines = original.Replace("\r\n", "\n").Split('\n');
 
+    // Only swallow a fenced block when BOTH markers are present. If a profile has
+    // the start marker but no matching end marker (e.g. the end line was deleted by
+    // hand), treating everything after the start as "inside the block" would discard
+    // the user's real config below it. In that malformed case we drop only the marker
+    // lines and stray sourcing lines, keeping everything else intact.
+    var hasStart = lines.Any(l => l.Contains(markerStart, StringComparison.Ordinal));
+    var hasEnd = lines.Any(l => l.Contains(markerEnd, StringComparison.Ordinal));
+    var stripBlock = hasStart && hasEnd;
+
     var kept = new List<string>(lines.Length);
     var inBlock = false;
     foreach (var line in lines)
     {
       if (!inBlock && line.Contains(markerStart, StringComparison.Ordinal))
       {
-        inBlock = true;
+        // Complete block: swallow up to the end marker. Malformed: drop just this line.
+        if (stripBlock)
+        {
+          inBlock = true;
+        }
         continue;
       }
       if (inBlock)
@@ -240,7 +253,12 @@ public static class ShellIntegration
         }
         continue;
       }
-      // Outside the block: drop any leftover line that sources our script.
+      // Outside the block: drop a stray end marker (malformed case) and any leftover
+      // line that sources our script.
+      if (line.Contains(markerEnd, StringComparison.Ordinal))
+      {
+        continue;
+      }
       if (line.Contains(strayLineToken, StringComparison.Ordinal))
       {
         continue;

--- a/app/Infrastructure/ShellIntegration.cs
+++ b/app/Infrastructure/ShellIntegration.cs
@@ -93,6 +93,221 @@ public static class ShellIntegration
     }
   }
 
+  /// <summary>
+  /// Reverses <see cref="InstallAll"/>: removes the binary, sourced script, shell
+  /// integration marker blocks, fish wrapper, and (Windows) cmd wrappers. When
+  /// <paramref name="purge"/> is true it also deletes the config directories.
+  /// The user's real Claude directory (~/.claude) is never touched.
+  /// </summary>
+  public static int UninstallAll(bool purge = false)
+  {
+    var userHome = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+    try
+    {
+      if (OperatingSystem.IsWindows())
+      {
+        UninstallWindows(userHome);
+      }
+      else
+      {
+        UninstallUnix(userHome);
+      }
+
+      if (purge)
+      {
+        PurgeConfig(userHome);
+      }
+      else
+      {
+        Console.WriteLine($"• Kept config: {Path.Combine(userHome, ".config", "copilot_here")} (use --purge to remove)");
+        Console.WriteLine($"• Kept config: {Path.Combine(userHome, ".config", "copilot-cli-docker")} (use --purge to remove)");
+      }
+
+      Console.WriteLine();
+      Console.WriteLine("✅ copilot_here removed.");
+      Console.WriteLine("   The shell function stays loaded until you restart your shell or open a new terminal.");
+      Console.WriteLine("   Installed via Homebrew, WinGet, or dotnet tool? Remove it with that package manager.");
+      Console.WriteLine("   Your Claude config (~/.claude) was left untouched.");
+      return 0;
+    }
+    catch (Exception ex)
+    {
+      Console.Error.WriteLine($"❌ Failed to uninstall: {ex.Message}");
+      return 1;
+    }
+  }
+
+  private static void UninstallUnix(string userHome)
+  {
+    // The sourced-script filename, used to scrub stray lines outside the marker block.
+    const string shToken = ".copilot_here.sh";
+
+    string[] profiles = [".bashrc", ".bash_profile", ".profile", ".zshrc", ".zprofile"];
+    foreach (var name in profiles)
+    {
+      if (RemoveBlock(Path.Combine(userHome, name), ShMarkerStart, ShMarkerEnd, shToken))
+      {
+        Console.WriteLine($"✓ Cleaned shell integration from {name}");
+      }
+    }
+
+    DeleteFileIfExists(Path.Combine(userHome, ".config", "fish", "conf.d", "copilot_here.fish"), "fish wrapper");
+    DeleteFileIfExists(Path.Combine(userHome, ".copilot_here.sh"), "shell script (~/.copilot_here.sh)");
+    DeleteFileIfExists(Path.Combine(userHome, ".local", "bin", "copilot_here"), "binary (~/.local/bin/copilot_here)");
+  }
+
+  private static void UninstallWindows(string userHome)
+  {
+    const string psToken = ".copilot_here.ps1";
+
+    var pwshProfile = Path.Combine(userHome, "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1");
+    var winPsProfile = Path.Combine(userHome, "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1");
+
+    if (RemoveBlock(pwshProfile, PsMarkerStart, PsMarkerEnd, psToken))
+    {
+      Console.WriteLine("✓ Cleaned shell integration from PowerShell profile");
+    }
+    if (RemoveBlock(winPsProfile, PsMarkerStart, PsMarkerEnd, psToken))
+    {
+      Console.WriteLine("✓ Cleaned shell integration from Windows PowerShell profile");
+    }
+
+    var binDir = Path.Combine(userHome, ".local", "bin");
+    DeleteFileIfExists(Path.Combine(binDir, "copilot_here.cmd"), "cmd wrapper (copilot_here.cmd)");
+    DeleteFileIfExists(Path.Combine(binDir, "copilot_yolo.cmd"), "cmd wrapper (copilot_yolo.cmd)");
+    DeleteFileIfExists(Path.Combine(userHome, ".copilot_here.ps1"), "PowerShell script (~/.copilot_here.ps1)");
+    // The running copilot_here.exe is locked on Windows, so this best-effort delete may
+    // fail here; the shell wrapper removes it once the process has exited.
+    DeleteFileIfExists(Path.Combine(binDir, "copilot_here.exe"), "binary (~/.local/bin/copilot_here.exe)");
+
+    Console.WriteLine("• Left ~/.local/bin on your user PATH (harmless; remove it manually if you want).");
+  }
+
+  private static void PurgeConfig(string userHome)
+  {
+    DeleteDirIfExists(Path.Combine(userHome, ".config", "copilot_here"), "config (~/.config/copilot_here)");
+    DeleteDirIfExists(Path.Combine(userHome, ".config", "copilot-cli-docker"), "config (~/.config/copilot-cli-docker)");
+  }
+
+  /// <summary>
+  /// Inverse of <see cref="EnsureBlock"/>: strips the marker-fenced region from a
+  /// profile while preserving everything around it. Also drops stray lines that
+  /// reference the sourced script outside the block (matching the cleanup the shell
+  /// updater does in __copilot_update_profile). Symlinked profiles (e.g. GNU Stow)
+  /// are written through to their resolved target. Returns true if the file changed.
+  /// </summary>
+  internal static bool RemoveBlock(string filePath, string markerStart, string markerEnd, string strayLineToken)
+  {
+    string original;
+    try
+    {
+      if (!File.Exists(filePath))
+      {
+        return false;
+      }
+      original = File.ReadAllText(filePath);
+    }
+    catch
+    {
+      return false;
+    }
+
+    if (!original.Contains(markerStart, StringComparison.Ordinal) &&
+        !original.Contains(strayLineToken, StringComparison.Ordinal))
+    {
+      return false;
+    }
+
+    // Preserve the file's dominant line ending.
+    var newline = original.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
+    var lines = original.Replace("\r\n", "\n").Split('\n');
+
+    var kept = new List<string>(lines.Length);
+    var inBlock = false;
+    foreach (var line in lines)
+    {
+      if (!inBlock && line.Contains(markerStart, StringComparison.Ordinal))
+      {
+        inBlock = true;
+        continue;
+      }
+      if (inBlock)
+      {
+        if (line.Contains(markerEnd, StringComparison.Ordinal))
+        {
+          inBlock = false;
+        }
+        continue;
+      }
+      // Outside the block: drop any leftover line that sources our script.
+      if (line.Contains(strayLineToken, StringComparison.Ordinal))
+      {
+        continue;
+      }
+      kept.Add(line);
+    }
+
+    // Trim trailing blank lines, then end with a single newline (unless empty).
+    while (kept.Count > 0 && kept[^1].Trim().Length == 0)
+    {
+      kept.RemoveAt(kept.Count - 1);
+    }
+    var rebuilt = kept.Count == 0 ? string.Empty : string.Join(newline, kept) + newline;
+
+    var target = ResolveSymlinkTarget(filePath);
+    File.WriteAllText(target, rebuilt);
+    return true;
+  }
+
+  private static string ResolveSymlinkTarget(string path)
+  {
+    try
+    {
+      var info = new FileInfo(path);
+      var resolved = info.ResolveLinkTarget(returnFinalTarget: true);
+      return resolved?.FullName ?? path;
+    }
+    catch
+    {
+      return path;
+    }
+  }
+
+  private static void DeleteFileIfExists(string path, string label)
+  {
+    if (!File.Exists(path))
+    {
+      return;
+    }
+    try
+    {
+      File.Delete(path);
+      Console.WriteLine($"✓ Removed {label}");
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"• Could not remove {label}: {ex.Message}");
+    }
+  }
+
+  private static void DeleteDirIfExists(string path, string label)
+  {
+    if (!Directory.Exists(path))
+    {
+      return;
+    }
+    try
+    {
+      Directory.Delete(path, recursive: true);
+      Console.WriteLine($"✓ Removed {label}");
+    }
+    catch (Exception ex)
+    {
+      Console.WriteLine($"• Could not remove {label}: {ex.Message}");
+    }
+  }
+
   private static IReadOnlyList<string> GetMissingTargetsUnix(string userHome)
   {
     var missing = new List<string>();

--- a/copilot_here.ps1
+++ b/copilot_here.ps1
@@ -266,6 +266,31 @@ function Reset-CopilotHere {
     Update-CopilotHere
 }
 
+# Uninstall function - delegates surgical removal to the binary, then removes the
+# sourced script and binary last (the binary can't reliably delete the file it's
+# running from on Windows, and this function deletes its own source). Passthrough
+# args carry --purge / --yes to the binary.
+function Uninstall-CopilotHere {
+    param([string[]]$PassthroughArgs = @())
+
+    if (Test-Path $script:CopilotHereBin) {
+        & $script:CopilotHereBin --uninstall @PassthroughArgs
+        $rc = $LASTEXITCODE
+        # Non-zero means the user declined the confirmation - leave everything in place.
+        if ($rc -ne 0) {
+            return
+        }
+    } else {
+        Write-Host "[WARNING]  Binary not found at $script:CopilotHereBin; removing scripts only." -ForegroundColor Yellow
+    }
+
+    Remove-Item -Path $script:CopilotHereScriptPath -Force -ErrorAction SilentlyContinue
+    Remove-Item -Path $script:CopilotHereBin -Force -ErrorAction SilentlyContinue
+
+    Write-Host ""
+    Write-Host "[OK] copilot_here uninstalled. Restart PowerShell to clear the loaded function." -ForegroundColor Green
+}
+
 # Check for updates (called at startup)
 function Test-CopilotHereUpdates {
     try {
@@ -335,6 +360,12 @@ function Test-ResetArg {
     return $resetArgs -contains $Arg
 }
 
+# Check if argument is an uninstall command
+function Test-UninstallArg {
+    param([string]$Arg)
+    return $Arg -eq "--uninstall"
+}
+
 # Safe Mode: Asks for confirmation before executing
 function copilot_here {
     $Arguments = @($args)
@@ -395,7 +426,14 @@ function copilot_here {
         Reset-CopilotHere
         return
     }
-    
+
+    # Handle --uninstall before binary check
+    if ($Arguments | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
+        Write-CopilotDebug "Uninstall argument detected"
+        Uninstall-CopilotHere -PassthroughArgs $Arguments
+        return
+    }
+
     # Check for updates at startup
     Write-CopilotDebug "Checking for updates..."
     if (Test-CopilotHereUpdates) { return }
@@ -471,7 +509,14 @@ function copilot_yolo {
         Reset-CopilotHere
         return
     }
-    
+
+    # Handle --uninstall before binary check
+    if ($Arguments | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
+        Write-CopilotDebug "Uninstall argument detected"
+        Uninstall-CopilotHere -PassthroughArgs $Arguments
+        return
+    }
+
     # Check for updates at startup
     Write-CopilotDebug "Checking for updates..."
     if (Test-CopilotHereUpdates) { return }

--- a/copilot_here.ps1
+++ b/copilot_here.ps1
@@ -427,8 +427,15 @@ function copilot_here {
         return
     }
 
-    # Handle --uninstall before binary check
-    if ($Arguments | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
+    # Handle --uninstall before binary check. Only look at tokens before "--" so a
+    # passthrough like `copilot_here -- --uninstall` targets the underlying tool, not
+    # the wrapper — uninstall is destructive, so it must only fire from a real flag.
+    $argsBeforeSeparator = @()
+    foreach ($a in $Arguments) {
+        if ($a -eq '--') { break }
+        $argsBeforeSeparator += $a
+    }
+    if ($argsBeforeSeparator | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
         Write-CopilotDebug "Uninstall argument detected"
         Uninstall-CopilotHere -PassthroughArgs $Arguments
         return
@@ -510,8 +517,15 @@ function copilot_yolo {
         return
     }
 
-    # Handle --uninstall before binary check
-    if ($Arguments | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
+    # Handle --uninstall before binary check. Only look at tokens before "--" so a
+    # passthrough like `copilot_here -- --uninstall` targets the underlying tool, not
+    # the wrapper — uninstall is destructive, so it must only fire from a real flag.
+    $argsBeforeSeparator = @()
+    foreach ($a in $Arguments) {
+        if ($a -eq '--') { break }
+        $argsBeforeSeparator += $a
+    }
+    if ($argsBeforeSeparator | Where-Object { Test-UninstallArg $_ } | Select-Object -First 1) {
         Write-CopilotDebug "Uninstall argument detected"
         Uninstall-CopilotHere -PassthroughArgs $Arguments
         return

--- a/copilot_here.sh
+++ b/copilot_here.sh
@@ -401,8 +401,13 @@ copilot_here() {
     fi
   done
 
-  # Handle --uninstall before binary check
+  # Handle --uninstall before binary check. Stop at "--" so a passthrough like
+  # `copilot_here -- --uninstall` targets the underlying tool, not the wrapper —
+  # uninstall is destructive, so it must only fire from a real wrapper-level flag.
   for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+      break
+    fi
     if __copilot_is_uninstall_arg "$arg"; then
       __copilot_debug "Uninstall argument detected"
       __copilot_uninstall "$@"
@@ -461,8 +466,13 @@ copilot_yolo() {
     fi
   done
 
-  # Handle --uninstall before binary check
+  # Handle --uninstall before binary check. Stop at "--" so a passthrough like
+  # `copilot_here -- --uninstall` targets the underlying tool, not the wrapper —
+  # uninstall is destructive, so it must only fire from a real wrapper-level flag.
   for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+      break
+    fi
     if __copilot_is_uninstall_arg "$arg"; then
       __copilot_debug "Uninstall argument detected"
       __copilot_uninstall "$@"

--- a/copilot_here.sh
+++ b/copilot_here.sh
@@ -270,6 +270,30 @@ __copilot_reset() {
   __copilot_update
 }
 
+# Uninstall function - delegates surgical removal to the binary, then removes the
+# sourced script and binary last (the binary can't reliably delete the file it's
+# running from, and this function deletes its own source). Passthrough args carry
+# --purge / --yes to the binary.
+__copilot_uninstall() {
+  if [ -x "$COPILOT_HERE_BIN" ]; then
+    "$COPILOT_HERE_BIN" --uninstall "$@"
+    local rc=$?
+    # Non-zero means the user declined the confirmation - leave everything in place.
+    if [ "$rc" -ne 0 ]; then
+      return "$rc"
+    fi
+  else
+    echo "⚠️  Binary not found at $COPILOT_HERE_BIN; removing scripts only."
+  fi
+
+  rm -f "$HOME/.copilot_here.sh"
+  rm -f "$COPILOT_HERE_BIN"
+
+  echo ""
+  echo "✅ copilot_here uninstalled. Restart your shell to clear the loaded function."
+  return 0
+}
+
 # Check for updates (called at startup)
 __copilot_check_for_updates() {
   __copilot_debug "Checking for updates..."
@@ -328,6 +352,18 @@ __copilot_is_reset_arg() {
   esac
 }
 
+# Check if argument is an uninstall command
+__copilot_is_uninstall_arg() {
+  case "$1" in
+    --uninstall)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 # Safe Mode: Asks for confirmation before executing
 copilot_here() {
   __copilot_debug "=== copilot_here called with args: $*"
@@ -364,7 +400,16 @@ copilot_here() {
       return $?
     fi
   done
-  
+
+  # Handle --uninstall before binary check
+  for arg in "$@"; do
+    if __copilot_is_uninstall_arg "$arg"; then
+      __copilot_debug "Uninstall argument detected"
+      __copilot_uninstall "$@"
+      return $?
+    fi
+  done
+
   # Check for updates at startup
   __copilot_debug "Checking for updates..."
   __copilot_check_for_updates || return 0
@@ -415,7 +460,16 @@ copilot_yolo() {
       return $?
     fi
   done
-  
+
+  # Handle --uninstall before binary check
+  for arg in "$@"; do
+    if __copilot_is_uninstall_arg "$arg"; then
+      __copilot_debug "Uninstall argument detected"
+      __copilot_uninstall "$@"
+      return $?
+    fi
+  done
+
   # Check for updates at startup
   __copilot_debug "Checking for updates..."
   __copilot_check_for_updates || return 0

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -1,0 +1,90 @@
+# Uninstalling copilot_here
+
+Most people want the one-liner in the [README](../README.md#-uninstalling). This page is the full reference: every file and directory the install creates, so you can remove things by hand or check that an automated uninstall got everything.
+
+## The easy way
+
+```bash
+copilot_here --uninstall            # binary, scripts, shell integration
+copilot_here --uninstall --purge    # the above + config dirs + pulled images
+copilot_here --uninstall --yes      # skip the confirmation prompt
+```
+
+Or, when the binary is broken or already gone, the self-contained remote script:
+
+```bash
+# Linux/macOS
+bash <(curl -fsSL https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.sh)
+```
+
+```powershell
+# Windows
+& ([scriptblock]::Create((iwr -UseBasicParsing 'https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.ps1').Content))
+```
+
+Both take `--purge` / `-Purge` and `--yes` / `-Yes`.
+
+> **`~/.claude` is never removed.** That directory is your real Claude Code config and login, shared with Claude Code itself, and no uninstall mode touches it.
+
+## What the install creates
+
+### Linux/macOS
+
+| What | Path |
+|------|------|
+| Native binary | `~/.local/bin/copilot_here` |
+| Sourced shell script | `~/.copilot_here.sh` |
+| Bash/Zsh integration | a marker block in `~/.bashrc`, `~/.bash_profile`, `~/.profile`, `~/.zshrc`, `~/.zprofile` (whichever exist) |
+| Fish integration | `~/.config/fish/conf.d/copilot_here.fish` |
+| Config (kept unless `--purge`) | `~/.config/copilot_here`, `~/.config/copilot-cli-docker` |
+| Per-project config (kept unless `--purge`) | `.copilot_here/` inside each repo you ran it in |
+| Docker images/containers (kept unless `--purge`) | containers named `copilot_here-*`, images under `ghcr.io/gordonbeeming/copilot_here` |
+
+### Windows
+
+| What | Path |
+|------|------|
+| Native binary | `%USERPROFILE%\.local\bin\copilot_here.exe` |
+| Sourced script | `%USERPROFILE%\.copilot_here.ps1` |
+| PowerShell integration | a marker block in `Documents\PowerShell\Microsoft.PowerShell_profile.ps1` and `Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1` |
+| cmd wrappers | `%USERPROFILE%\.local\bin\copilot_here.cmd`, `copilot_yolo.cmd` |
+| User PATH entry | `%USERPROFILE%\.local\bin` added to your user PATH |
+| Config (kept unless `--purge`) | `%USERPROFILE%\.config\copilot_here`, `%USERPROFILE%\.config\copilot-cli-docker` |
+
+## Manual removal checklist
+
+If you'd rather do it yourself, or want to confirm nothing was left behind:
+
+1. **Stop running containers** so the binary isn't in use:
+   ```bash
+   docker ps --filter "name=copilot_here-" -q | xargs -r docker stop
+   ```
+2. **Remove the shell integration block** from each profile listed above. It's fenced by these markers — delete everything from the start marker to the end marker, inclusive:
+   ```bash
+   # >>> copilot_here >>>
+   ...
+   # <<< copilot_here <<<
+   ```
+3. **Delete the script, binary, and wrappers:**
+   ```bash
+   rm -f ~/.copilot_here.sh ~/.local/bin/copilot_here
+   rm -f ~/.config/fish/conf.d/copilot_here.fish
+   ```
+   On Windows, also remove `~/.copilot_here.ps1` and the two `.cmd` wrappers in `~/.local/bin`.
+4. **(Optional) Remove config and images:**
+   ```bash
+   rm -rf ~/.config/copilot_here ~/.config/copilot-cli-docker
+   docker images "ghcr.io/gordonbeeming/copilot_here*" -q | xargs -r docker rmi -f
+   ```
+5. **Restart your shell** (or open a new terminal). The `copilot_here` function stays loaded in your current session until then.
+
+## Installed through a package manager?
+
+The methods above are for the script/binary install. If you used a package manager, uninstall through it instead:
+
+```bash
+brew uninstall --cask copilot-here          # Homebrew (macOS)
+brew uninstall copilot_here                 # Homebrew (Linux)
+winget uninstall GordonBeeming.CopilotHere  # WinGet (Windows)
+dotnet tool uninstall -g copilot_here       # .NET global tool
+```

--- a/tests/CopilotHere.UnitTests/HelpOutputTests.cs
+++ b/tests/CopilotHere.UnitTests/HelpOutputTests.cs
@@ -77,6 +77,9 @@ public class HelpOutputTests
   [Arguments("--yolo")]
   [Arguments("--update")]
   [Arguments("--install-shells")]
+  [Arguments("--uninstall")]
+  [Arguments("--purge")]
+  [Arguments("--yes")]
   [Arguments("--help2")]
   public async Task RootCommand_HasOption(string option)
   {

--- a/tests/CopilotHere.UnitTests/ShellIntegrationTests.cs
+++ b/tests/CopilotHere.UnitTests/ShellIntegrationTests.cs
@@ -71,6 +71,30 @@ public class ShellIntegrationTests
   }
 
   [Test]
+  public async Task RemoveBlock_MalformedBlock_MissingEndMarker_PreservesUserContent()
+  {
+    // A start marker with no matching end marker must NOT swallow the rest of the file.
+    var profile = Path.Combine(_tempDir, ".zshrc");
+    var content =
+      "export EDITOR=vim\n" +
+      $"{MarkerStart}\n" +
+      "source \"$HOME/.copilot_here.sh\"\n" +
+      "export FOO=bar\n" +
+      "alias g=git\n";
+    File.WriteAllText(profile, content);
+
+    var changed = ShellIntegration.RemoveBlock(profile, MarkerStart, MarkerEnd, Token);
+    var result = File.ReadAllText(profile);
+
+    await Assert.That(changed).IsTrue();
+    await Assert.That(result).Contains("export EDITOR=vim");
+    await Assert.That(result).Contains("export FOO=bar");
+    await Assert.That(result).Contains("alias g=git");
+    await Assert.That(result).DoesNotContain(MarkerStart);
+    await Assert.That(result).DoesNotContain(".copilot_here.sh");
+  }
+
+  [Test]
   public async Task RemoveBlock_NoMarkersOrStrayLines_LeavesFileUnchanged()
   {
     var profile = Path.Combine(_tempDir, ".zshrc");

--- a/tests/CopilotHere.UnitTests/ShellIntegrationTests.cs
+++ b/tests/CopilotHere.UnitTests/ShellIntegrationTests.cs
@@ -5,6 +5,94 @@ namespace CopilotHere.Tests;
 
 public class ShellIntegrationTests
 {
+  private const string MarkerStart = "# >>> copilot_here >>>";
+  private const string MarkerEnd = "# <<< copilot_here <<<";
+  private const string Token = ".copilot_here.sh";
+
+  private string _tempDir = null!;
+
+  [Before(Test)]
+  public void Setup()
+  {
+    _tempDir = Path.Combine(Path.GetTempPath(), $"copilot_here_uninstall_{Guid.NewGuid():N}");
+    Directory.CreateDirectory(_tempDir);
+  }
+
+  [After(Test)]
+  public void Cleanup()
+  {
+    if (Directory.Exists(_tempDir))
+      Directory.Delete(_tempDir, recursive: true);
+  }
+
+  [Test]
+  public async Task RemoveBlock_StripsMarkerBlock_PreservesSurroundingContent()
+  {
+    var profile = Path.Combine(_tempDir, ".zshrc");
+    var content =
+      "export EDITOR=vim\n" +
+      "alias g=git\n" +
+      "\n" +
+      $"{MarkerStart}\n" +
+      "if [ -d \"$HOME/.local/bin\" ]; then\n" +
+      "  export PATH=\"$HOME/.local/bin:$PATH\"\n" +
+      "fi\n" +
+      "source \"$HOME/.copilot_here.sh\"\n" +
+      $"{MarkerEnd}\n" +
+      "\n" +
+      "export FOO=bar\n";
+    File.WriteAllText(profile, content);
+
+    var changed = ShellIntegration.RemoveBlock(profile, MarkerStart, MarkerEnd, Token);
+    var result = File.ReadAllText(profile);
+
+    await Assert.That(changed).IsTrue();
+    await Assert.That(result).Contains("export EDITOR=vim");
+    await Assert.That(result).Contains("alias g=git");
+    await Assert.That(result).Contains("export FOO=bar");
+    await Assert.That(result).DoesNotContain(MarkerStart);
+    await Assert.That(result).DoesNotContain(MarkerEnd);
+    await Assert.That(result).DoesNotContain(".copilot_here.sh");
+  }
+
+  [Test]
+  public async Task RemoveBlock_RemovesStraySourcingLine_WithoutMarkers()
+  {
+    var profile = Path.Combine(_tempDir, ".bashrc");
+    File.WriteAllText(profile, "alias ll=\"ls -la\"\nsource \"$HOME/.copilot_here.sh\"\nexport BAZ=1\n");
+
+    var changed = ShellIntegration.RemoveBlock(profile, MarkerStart, MarkerEnd, Token);
+    var result = File.ReadAllText(profile);
+
+    await Assert.That(changed).IsTrue();
+    await Assert.That(result).Contains("alias ll=\"ls -la\"");
+    await Assert.That(result).Contains("export BAZ=1");
+    await Assert.That(result).DoesNotContain(".copilot_here.sh");
+  }
+
+  [Test]
+  public async Task RemoveBlock_NoMarkersOrStrayLines_LeavesFileUnchanged()
+  {
+    var profile = Path.Combine(_tempDir, ".zshrc");
+    var original = "export EDITOR=vim\nalias g=git\n";
+    File.WriteAllText(profile, original);
+
+    var changed = ShellIntegration.RemoveBlock(profile, MarkerStart, MarkerEnd, Token);
+
+    await Assert.That(changed).IsFalse();
+    await Assert.That(File.ReadAllText(profile)).IsEqualTo(original);
+  }
+
+  [Test]
+  public async Task RemoveBlock_MissingFile_ReturnsFalse()
+  {
+    var profile = Path.Combine(_tempDir, "does-not-exist");
+
+    var changed = ShellIntegration.RemoveBlock(profile, MarkerStart, MarkerEnd, Token);
+
+    await Assert.That(changed).IsFalse();
+  }
+
   [Test]
   public async Task BuildCmdWrapper_UsesArgsSplatForForwarding()
   {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -98,6 +98,16 @@ Remove-CopilotItem -Path $psScript -Label "PowerShell script (~/.copilot_here.ps
 Remove-CopilotItem -Path $bin -Label "binary ($bin)"
 
 if ($Purge) {
+    # Best-effort: remove copilot_here containers and pulled images so -Purge
+    # matches the CLI's --purge. Skipped silently when docker isn't available.
+    try {
+        if (Get-Command docker -ErrorAction SilentlyContinue) {
+            $containers = docker ps -aq --filter "name=copilot_here-" 2>$null
+            if ($containers) { docker rm -f $containers 2>&1 | Out-Null; Write-Host "✓ Removed copilot_here containers" }
+            $images = docker images --filter=reference='ghcr.io/gordonbeeming/copilot_here*' -q 2>$null | Select-Object -Unique
+            if ($images) { docker rmi -f $images 2>&1 | Out-Null; Write-Host "✓ Removed copilot_here images" }
+        }
+    } catch { }
     Remove-CopilotItem -Path (Join-Path $home_ ".config/copilot_here") -Label "config (~/.config/copilot_here)"
     Remove-CopilotItem -Path (Join-Path $home_ ".config/copilot-cli-docker") -Label "config (~/.config/copilot-cli-docker)"
 } else {

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,110 @@
+# PowerShell uninstall script for copilot_here.
+# Self-contained: removes the install by known paths and does NOT depend on the
+# binary still working, so it cleans up even a half-broken install.
+#
+# Usage:
+#   iex ([System.Text.Encoding]::UTF8.GetString((iwr -UseBasicParsing 'https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.ps1').Content))
+#   Add -Purge to also delete config dirs, -Yes to skip the confirmation prompt:
+#   & ([scriptblock]::Create((iwr -UseBasicParsing '.../uninstall.ps1').Content)) -Purge -Yes
+#
+# Never touches ~/.claude (your real Claude Code config).
+
+[CmdletBinding()]
+param(
+    [switch]$Purge,
+    [switch]$Yes
+)
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$home_ = if ($env:USERPROFILE) { $env:USERPROFILE } elseif ($env:HOME) { $env:HOME } else { [Environment]::GetFolderPath('UserProfile') }
+
+$binDir = Join-Path (Join-Path $home_ ".local") "bin"
+$binName = if ($env:USERPROFILE) { "copilot_here.exe" } else { "copilot_here" }
+$bin = if ($env:COPILOT_HERE_BIN) { $env:COPILOT_HERE_BIN } else { Join-Path $binDir $binName }
+$psScript = Join-Path $home_ ".copilot_here.ps1"
+$markerStart = "# >>> copilot_here >>>"
+$markerEnd = "# <<< copilot_here <<<"
+
+Write-Host "🧹 Uninstalling copilot_here" -ForegroundColor Cyan
+Write-Host "   This removes the binary, PowerShell script, cmd wrappers, and shell integration."
+if ($Purge) {
+    Write-Host "   -Purge: also deleting ~/.config/copilot_here and ~/.config/copilot-cli-docker"
+}
+Write-Host "   Your Claude config (~/.claude) is left untouched."
+
+if (-not $Yes) {
+    $response = Read-Host "   Continue? [y/N]"
+    if ($response -notmatch '^[yY]') {
+        Write-Host "❌ Uninstall cancelled." -ForegroundColor Red
+        return
+    }
+}
+
+function Remove-CopilotProfileBlock {
+    param([string]$ProfilePath)
+
+    if (-not (Test-Path $ProfilePath)) { return }
+    $content = Get-Content $ProfilePath -Raw -ErrorAction SilentlyContinue
+    if ([string]::IsNullOrEmpty($content)) { return }
+    if (-not ($content.Contains($markerStart) -or $content -match 'copilot_here\.ps1')) { return }
+
+    if ($content.Contains($markerStart)) {
+        $startIndex = $content.IndexOf($markerStart)
+        $endIndex = $content.IndexOf($markerEnd, $startIndex)
+        if ($endIndex -gt $startIndex) {
+            $endIndex += $markerEnd.Length
+            $before = $content.Substring(0, $startIndex)
+            $after = if ($endIndex -lt $content.Length) { $content.Substring($endIndex) } else { "" }
+            $content = $before + $after
+        }
+    }
+    # Drop any stray sourcing lines left outside the block.
+    $content = $content -replace '(?m)^.*copilot_here\.ps1.*$[\r\n]*', ''
+    $content = $content.TrimEnd()
+    if ($content.Length -gt 0) { $content += "`n" }
+
+    $resolved = Resolve-Path $ProfilePath -ErrorAction SilentlyContinue
+    $target = if ($resolved) { $resolved.Path } else { $ProfilePath }
+    [System.IO.File]::WriteAllText($target, $content, [System.Text.Encoding]::UTF8)
+    Write-Host "✓ Cleaned shell integration from $(Split-Path $ProfilePath -Leaf)"
+}
+
+function Remove-CopilotItem {
+    param([string]$Path, [string]$Label)
+    if (Test-Path $Path) {
+        Remove-Item -Path $Path -Force -Recurse -ErrorAction SilentlyContinue
+        Write-Host "✓ Removed $Label"
+    }
+}
+
+# Stop any running containers so the binary isn't in use.
+try {
+    $running = docker ps --filter "name=copilot_here-" -q 2>$null
+    if ($running) {
+        Write-Host "🛑 Stopping copilot_here containers..."
+        docker stop $running 2>&1 | Out-Null
+    }
+} catch { }
+
+Remove-CopilotProfileBlock -ProfilePath (Join-Path $home_ "Documents\PowerShell\Microsoft.PowerShell_profile.ps1")
+Remove-CopilotProfileBlock -ProfilePath (Join-Path $home_ "Documents\WindowsPowerShell\Microsoft.PowerShell_profile.ps1")
+# Also handle Unix-style PowerShell profiles for pwsh on Linux/macOS.
+Remove-CopilotProfileBlock -ProfilePath (Join-Path $home_ ".config/powershell/Microsoft.PowerShell_profile.ps1")
+
+Remove-CopilotItem -Path (Join-Path $binDir "copilot_here.cmd") -Label "cmd wrapper (copilot_here.cmd)"
+Remove-CopilotItem -Path (Join-Path $binDir "copilot_yolo.cmd") -Label "cmd wrapper (copilot_yolo.cmd)"
+Remove-CopilotItem -Path $psScript -Label "PowerShell script (~/.copilot_here.ps1)"
+Remove-CopilotItem -Path $bin -Label "binary ($bin)"
+
+if ($Purge) {
+    Remove-CopilotItem -Path (Join-Path $home_ ".config/copilot_here") -Label "config (~/.config/copilot_here)"
+    Remove-CopilotItem -Path (Join-Path $home_ ".config/copilot-cli-docker") -Label "config (~/.config/copilot-cli-docker)"
+} else {
+    Write-Host "• Kept config dirs (re-run with -Purge to remove them)"
+}
+
+Write-Host ""
+Write-Host "✅ copilot_here uninstalled." -ForegroundColor Green
+Write-Host "   Restart PowerShell or open a new terminal to clear the loaded function."
+Write-Host "   Installed via WinGet / dotnet tool? Remove it with that package manager."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -57,7 +57,7 @@ __copilot_uninstall_main() {
   __copilot_strip_profile() {
     local profile="$1"
     [ -f "$profile" ] || return 0
-    grep -qF "$marker_start" "$profile" 2>/dev/null || grep -q "copilot_here.sh" "$profile" 2>/dev/null || return 0
+    grep -qF "$marker_start" "$profile" 2>/dev/null || grep -qF "copilot_here.sh" "$profile" 2>/dev/null || return 0
 
     # Only strip a fenced block when both markers are present. With a start marker
     # but no matching end marker, treating everything after the start as in-block
@@ -102,6 +102,20 @@ __copilot_uninstall_main() {
   __copilot_rm "$bin" "binary ($bin)"
 
   if [ "$purge" -eq 1 ]; then
+    # Best-effort: remove copilot_here containers and pulled images so --purge
+    # matches the CLI's --purge. Skipped silently when docker isn't available.
+    if command -v docker >/dev/null 2>&1; then
+      local containers
+      containers=$(docker ps -aq --filter "name=copilot_here-" 2>/dev/null)
+      if [ -n "$containers" ]; then
+        docker rm -f $containers >/dev/null 2>&1 && echo "✓ Removed copilot_here containers"
+      fi
+      local images
+      images=$(docker images --filter=reference='ghcr.io/gordonbeeming/copilot_here*' -q 2>/dev/null | sort -u)
+      if [ -n "$images" ]; then
+        docker rmi -f $images >/dev/null 2>&1 && echo "✓ Removed copilot_here images"
+      fi
+    fi
     if [ -d "$HOME/.config/copilot_here" ]; then
       rm -rf "$HOME/.config/copilot_here" && echo "✓ Removed config (~/.config/copilot_here)"
     fi

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -59,11 +59,18 @@ __copilot_uninstall_main() {
     [ -f "$profile" ] || return 0
     grep -qF "$marker_start" "$profile" 2>/dev/null || grep -q "copilot_here.sh" "$profile" 2>/dev/null || return 0
 
+    # Only strip a fenced block when both markers are present. With a start marker
+    # but no matching end marker, treating everything after the start as in-block
+    # would discard the user's config below it; instead drop only the marker and
+    # stray sourcing lines.
+    local has_end=0
+    grep -qF "$marker_end" "$profile" 2>/dev/null && has_end=1
+
     local temp
     temp=$(mktemp)
-    awk -v start="$marker_start" -v end="$marker_end" '
+    awk -v start="$marker_start" -v end="$marker_end" -v strip="$has_end" '
       BEGIN { in_block=0 }
-      $0 ~ start { in_block=1; next }
+      $0 ~ start { if (strip == "1") in_block=1; next }
       $0 ~ end { in_block=0; next }
       !in_block && $0 !~ /copilot_here\.sh/ { print }
     ' "$profile" > "$temp"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# Bash/Zsh uninstall script for copilot_here.
+# Self-contained: it removes the install by known paths and does NOT depend on the
+# binary still working, so it cleans up even a half-broken install.
+#
+# Usage:
+#   bash <(curl -fsSL https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.sh)
+#   bash <(curl -fsSL .../uninstall.sh) --purge   # also delete config dirs
+#   bash <(curl -fsSL .../uninstall.sh) --yes      # skip the confirmation prompt
+#
+# Never touches ~/.claude (your real Claude Code config).
+
+__copilot_uninstall_main() {
+  local purge=0
+  local assume_yes=0
+  local arg
+  for arg in "$@"; do
+    case "$arg" in
+      --purge) purge=1 ;;
+      --yes|-y) assume_yes=1 ;;
+    esac
+  done
+
+  local bin="${COPILOT_HERE_BIN:-$HOME/.local/bin/copilot_here}"
+  local script="$HOME/.copilot_here.sh"
+  local fish_conf="$HOME/.config/fish/conf.d/copilot_here.fish"
+  local marker_start="# >>> copilot_here >>>"
+  local marker_end="# <<< copilot_here <<<"
+
+  echo "🧹 Uninstalling copilot_here"
+  echo "   This removes the binary, shell script, and shell integration."
+  if [ "$purge" -eq 1 ]; then
+    echo "   --purge: also deleting ~/.config/copilot_here and ~/.config/copilot-cli-docker"
+  fi
+  echo "   Your Claude config (~/.claude) is left untouched."
+
+  if [ "$assume_yes" -ne 1 ]; then
+    printf "   Continue? [y/N]: "
+    read -r response
+    local lower
+    lower=$(echo "$response" | tr '[:upper:]' '[:lower:]')
+    if [ "$lower" != "y" ] && [ "$lower" != "yes" ]; then
+      echo "❌ Uninstall cancelled."
+      return 1
+    fi
+  fi
+
+  # Stop any running containers so the binary isn't in use.
+  local running
+  running=$(docker ps --filter "name=copilot_here-" -q 2>/dev/null)
+  if [ -n "$running" ]; then
+    echo "🛑 Stopping copilot_here containers..."
+    docker stop $running >/dev/null 2>&1
+  fi
+
+  # Strip the marker block (and any stray sourcing line) from each profile.
+  __copilot_strip_profile() {
+    local profile="$1"
+    [ -f "$profile" ] || return 0
+    grep -qF "$marker_start" "$profile" 2>/dev/null || grep -q "copilot_here.sh" "$profile" 2>/dev/null || return 0
+
+    local temp
+    temp=$(mktemp)
+    awk -v start="$marker_start" -v end="$marker_end" '
+      BEGIN { in_block=0 }
+      $0 ~ start { in_block=1; next }
+      $0 ~ end { in_block=0; next }
+      !in_block && $0 !~ /copilot_here\.sh/ { print }
+    ' "$profile" > "$temp"
+
+    # Preserve symlinks (e.g. GNU Stow): write through the resolved target.
+    if [ -L "$profile" ]; then
+      local real
+      real="$(readlink -f "$profile")"
+      mv "$temp" "$real"
+    else
+      cat "$temp" > "$profile" && rm -f "$temp"
+    fi
+    echo "✓ Cleaned shell integration from $(basename "$profile")"
+  }
+
+  __copilot_strip_profile "$HOME/.bashrc"
+  __copilot_strip_profile "$HOME/.bash_profile"
+  __copilot_strip_profile "$HOME/.profile"
+  __copilot_strip_profile "$HOME/.zshrc"
+  __copilot_strip_profile "$HOME/.zprofile"
+
+  __copilot_rm() {
+    [ -e "$1" ] || return 0
+    rm -f "$1" && echo "✓ Removed $2"
+  }
+
+  __copilot_rm "$fish_conf" "fish wrapper"
+  __copilot_rm "$script" "shell script (~/.copilot_here.sh)"
+  __copilot_rm "$bin" "binary ($bin)"
+
+  if [ "$purge" -eq 1 ]; then
+    if [ -d "$HOME/.config/copilot_here" ]; then
+      rm -rf "$HOME/.config/copilot_here" && echo "✓ Removed config (~/.config/copilot_here)"
+    fi
+    if [ -d "$HOME/.config/copilot-cli-docker" ]; then
+      rm -rf "$HOME/.config/copilot-cli-docker" && echo "✓ Removed config (~/.config/copilot-cli-docker)"
+    fi
+  else
+    echo "• Kept config dirs (re-run with --purge to remove them)"
+  fi
+
+  echo ""
+  echo "✅ copilot_here uninstalled."
+  echo "   Restart your shell or open a new terminal to clear the loaded function."
+  echo "   Installed via Homebrew / dotnet tool? Remove it with that package manager."
+  return 0
+}
+
+__copilot_uninstall_main "$@"
+__copilot_uninstall_status=$?
+# Work whether the script is executed (bash <(...)) or sourced (source <(...)).
+return $__copilot_uninstall_status 2>/dev/null || exit $__copilot_uninstall_status


### PR DESCRIPTION
## Summary

- Adds a first-class uninstall so nobody has to read the install script and reverse it by hand (#118). `ShellIntegration.UninstallAll()` is the precise inverse of `InstallAll()`: it strips the shell-integration marker blocks, then removes the binary, sourced script, fish wrapper, and cmd wrappers. `--purge` also deletes the config dirs and pulled images. It never touches `~/.claude`.
- Surfaces it three ways: `copilot_here --uninstall` (`--purge`, `--yes`) in the CLI, matching handlers in the `copilot_here.sh` / `.ps1` wrappers (parity with `--update`), and self-contained `uninstall.sh` / `uninstall.ps1` remote scripts that clean up even when the binary is broken.
- Docs: a README "Uninstalling" section and a full `docs/uninstall.md` manual checklist (every file/dir the install creates, per OS).

## Notes for reviewers

- The Windows user-PATH entry (`~/.local/bin`) is intentionally left in place — removing a single PATH segment safely is fiddly, and an empty dir on PATH is harmless. It's documented instead.
- Per-project `.copilot_here/` dirs can't be enumerated globally, so `--purge` only removes the global config + (best-effort) containers/images.
- `--purge` container/image cleanup is best-effort: if the runtime is missing or a command fails, it's reported and skipped so the rest of the uninstall still completes.

## Test plan

- [x] `dotnet run` unit tests — 623/623 pass (4 new `RemoveBlock` cases + 3 new CLI-option assertions).
- [x] Binary round-trip in a throwaway `HOME`: `--uninstall --yes` removes binary/script/integration, strips the marker block while preserving surrounding profile content, keeps config + `~/.claude`.
- [x] `--purge` removes config dirs (and pulled images), keeps `~/.claude`.
- [x] Remote `uninstall.sh` verified end-to-end: block-strip preserves user content, stray sourcing lines removed, cancel path leaves everything in place.
- [x] `bash -n` + PowerShell parse checks pass for both wrappers and both remote scripts.
- [ ] CI publishes `uninstall.sh` / `uninstall.ps1` to the `cli-latest` release.

Closes #118