### PR TITLE
docs: drop the Claude-config wording from uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ That removes the binary, the sourced script, and the shell integration from your
 copilot_here --uninstall --purge   # also deletes config dirs + pulled images
 ```
 
-Add `--yes` to skip the confirmation prompt. The uninstall never touches `~/.claude`, your real Claude Code config.
+Add `--yes` to skip the confirmation prompt.
 
 ### Remote script (if the install is broken or already half-gone)
 

--- a/app/Commands/Run/RunCommand.cs
+++ b/app/Commands/Run/RunCommand.cs
@@ -133,7 +133,7 @@ public sealed class RunCommand : ICommand
     _installShellsOption = new Option<bool>("--install-shells") { Description = "Install shell integrations (bash/zsh/fish + PowerShell/cmd)" };
 
     _uninstallOption = new Option<bool>("--uninstall") { Description = "Remove copilot_here (binary, scripts, shell integration). Add --purge to also delete config and pulled images" };
-    _purgeOption = new Option<bool>("--purge") { Description = "With --uninstall: also delete config dirs and pulled Docker images (never touches ~/.claude)" };
+    _purgeOption = new Option<bool>("--purge") { Description = "With --uninstall: also delete config dirs and pulled Docker images" };
     _yesOption = new Option<bool>("--yes") { Description = "Skip confirmation prompts (for --uninstall)" };
     _yesOption.Aliases.Add("-y");
 

--- a/app/Infrastructure/ShellIntegration.cs
+++ b/app/Infrastructure/ShellIntegration.cs
@@ -97,7 +97,6 @@ public static class ShellIntegration
   /// Reverses <see cref="InstallAll"/>: removes the binary, sourced script, shell
   /// integration marker blocks, fish wrapper, and (Windows) cmd wrappers. When
   /// <paramref name="purge"/> is true it also deletes the config directories.
-  /// The user's real Claude directory (~/.claude) is never touched.
   /// </summary>
   public static int UninstallAll(bool purge = false)
   {
@@ -128,7 +127,6 @@ public static class ShellIntegration
       Console.WriteLine("✅ copilot_here removed.");
       Console.WriteLine("   The shell function stays loaded until you restart your shell or open a new terminal.");
       Console.WriteLine("   Installed via Homebrew, WinGet, or dotnet tool? Remove it with that package manager.");
-      Console.WriteLine("   Your Claude config (~/.claude) was left untouched.");
       return 0;
     }
     catch (Exception ex)

--- a/docs/uninstall.md
+++ b/docs/uninstall.md
@@ -24,8 +24,6 @@ bash <(curl -fsSL https://github.com/GordonBeeming/copilot_here/releases/downloa
 
 Both take `--purge` / `-Purge` and `--yes` / `-Yes`.
 
-> **`~/.claude` is never removed.** That directory is your real Claude Code config and login, shared with Claude Code itself, and no uninstall mode touches it.
-
 ## What the install creates
 
 ### Linux/macOS

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -6,8 +6,6 @@
 #   iex ([System.Text.Encoding]::UTF8.GetString((iwr -UseBasicParsing 'https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.ps1').Content))
 #   Add -Purge to also delete config dirs, -Yes to skip the confirmation prompt:
 #   & ([scriptblock]::Create((iwr -UseBasicParsing '.../uninstall.ps1').Content)) -Purge -Yes
-#
-# Never touches ~/.claude (your real Claude Code config).
 
 [CmdletBinding()]
 param(
@@ -31,7 +29,6 @@ Write-Host "   This removes the binary, PowerShell script, cmd wrappers, and she
 if ($Purge) {
     Write-Host "   -Purge: also deleting ~/.config/copilot_here and ~/.config/copilot-cli-docker"
 }
-Write-Host "   Your Claude config (~/.claude) is left untouched."
 
 if (-not $Yes) {
     $response = Read-Host "   Continue? [y/N]"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,8 +7,6 @@
 #   bash <(curl -fsSL https://github.com/GordonBeeming/copilot_here/releases/download/cli-latest/uninstall.sh)
 #   bash <(curl -fsSL .../uninstall.sh) --purge   # also delete config dirs
 #   bash <(curl -fsSL .../uninstall.sh) --yes      # skip the confirmation prompt
-#
-# Never touches ~/.claude (your real Claude Code config).
 
 __copilot_uninstall_main() {
   local purge=0
@@ -32,7 +30,6 @@ __copilot_uninstall_main() {
   if [ "$purge" -eq 1 ]; then
     echo "   --purge: also deleting ~/.config/copilot_here and ~/.config/copilot-cli-docker"
   fi
-  echo "   Your Claude config (~/.claude) is left untouched."
 
   if [ "$assume_yes" -ne 1 ]; then
     printf "   Continue? [y/N]: "


### PR DESCRIPTION
## Summary

- Removes the "Your Claude config (`~/.claude`) is left untouched" line from the uninstall output (CLI + remote `uninstall.sh` / `uninstall.ps1`), and the matching notes in the README "Uninstalling" section, `docs/uninstall.md`, and the `--purge` help text.
- It read as odd, mid-uninstall noise. Behaviour is unchanged — uninstall never removed `~/.claude` (it's simply not in the removal list); only the wording is gone.

## Test plan

- [x] `dotnet build` green; uninstall surfaces have no remaining Claude-config mentions.
- [x] `bash -n uninstall.sh` + PowerShell parse pass.
- [x] Ran `uninstall.sh` — intro output no longer shows the Claude line.